### PR TITLE
fix(vport): correct auto_negotiate/fec behavior

### DIFF
--- a/snappi_ixnetwork/vport.py
+++ b/snappi_ixnetwork/vport.py
@@ -593,10 +593,25 @@ class Vport(object):
             "{0}".format(auto_field_name): False
             if auto_negotiate is None
             else auto_negotiate,
-            "enableRsFec": False if rs_fec is None else rs_fec,
             "linkTraining": False if link_training is None else link_training,
             "speedAuto": advertise,
         }
+        if auto_negotiate:
+            proposed_import.update(
+                useANResults=True,
+                firecodeForceOn=False,
+                rsFecForceOn=False,
+                forceDisableFEC=False,
+                rsFecAdvertise=False if rs_fec is None else rs_fec,
+                rsFecRequest=False if rs_fec is None else rs_fec,
+            )
+        else:
+            proposed_import.update(
+                useANResults=False,
+                firecodeForceOn=False,
+                rsFecForceOn=False if rs_fec is None else rs_fec,
+                forceDisableFEC=True if rs_fec is None else not rs_fec,
+            )
         proposed_import["media"] = layer1.get("media", with_default=True)
         self._add_l1config_import(vport, proposed_import, imports)
 

--- a/tests/layer1/test_layer1_auto_negotiate.py
+++ b/tests/layer1/test_layer1_auto_negotiate.py
@@ -1,0 +1,54 @@
+from itertools import product
+
+import pytest
+
+
+_PORT_NAME = "p1"
+
+
+@pytest.mark.parametrize(
+    "autonego, rs_fec",
+    product([True, False], [True, False])
+)
+def test_auto_negotiate(api, utils, autonego, rs_fec):
+    """
+    Configure a port layer1 configuration with,
+    - ieee_media_defaults: false
+
+    Validate,
+    - layer1 auto negotiate properties is as expected
+    """
+    config = api.config()
+    p1 = config.ports.port(name=_PORT_NAME, location=utils.settings.ports[0])[-1]
+    l1 = config.layer1.layer1(name="l1")[-1]
+    l1.port_names = [p1.name]
+    l1.speed = utils.settings.speed
+    l1.media = utils.settings.media
+    l1.ieee_media_defaults = False
+    l1.auto_negotiate = autonego
+    l1.auto_negotiation.rs_fec = rs_fec
+    api.set_config(config)
+    validate_auto_negotiate_config(api, autonego, rs_fec)
+
+
+def validate_auto_negotiate_config(api, autonego, rs_fec):
+    """
+    Validate layer1 auto negotiate configs using restpy
+    """
+    ixnetwork = api._ixnetwork
+    port = ixnetwork.Vport.find(Name=_PORT_NAME)
+    lan = getattr(port.L1Config, port.Type[0].upper() + port.Type[1:])
+
+    assert lan.EnableAutoNegotiation == autonego
+    if autonego:
+        assert lan.UseANResults
+        assert not lan.FirecodeForceOn
+        assert not lan.RsFecForceOn
+        assert not lan.ForceDisableFEC
+        assert lan.RsFecAdvertise == rs_fec
+        assert lan.RsFecRequest == rs_fec
+    else:
+        assert not lan.UseANResults
+        assert not lan.FirecodeForceOn
+        assert lan.RsFecForceOn == rs_fec
+        assert lan.ForceDisableFEC != rs_fec


### PR DESCRIPTION
I notice the behavior of auto_negotiate/fec to be a bit weird

here is what I expected:
* when `auto_negotiate` is set to `yes`, it should adopt the an results
* when `auto_negotiate` is set to `no`, it should force on/off fec according to the value of `rs_fec`