### PR TITLE
Let traffic endpoints (IPv4/ Ethernet) decide MACsec traffic type(IPv4 or ethernet/VLAN) and not default ethernet/VLAN encapsulation property of MACsec SecureEntity device

### DIFF
--- a/snappi_ixnetwork/device/interface.py
+++ b/snappi_ixnetwork/device/interface.py
@@ -61,9 +61,6 @@ class Ethernet(Base):
         ipv4_addresses = ethernet.get("ipv4_addresses")
         if ipv4_addresses is None:
             return
-        if self._ngpf.is_ip_allowed == False:
-            self.logger.debug("Skip IPv4 configuration")
-            return
 
         eth_name = ethernet.name
         if eth_name not in self._ngpf.ether_v4gateway_map:
@@ -73,23 +70,24 @@ class Ethernet(Base):
             self._ngpf.ether_v4gateway_map[eth_name].append(
                 ipv4_address.gateway
             )
-            ixn_ip = self.create_node_elemet(
-                ixn_eth, "ipv4", ipv4_address.get("name")
-            )
-            self._ngpf.set_device_info(ipv4_address, ixn_ip)
-            self.configure_multivalues(ipv4_address, ixn_ip, Ethernet._IP)
-            if ipv4_address.gateway_mac.choice == "value":
-                self.configure_multivalues_with_choice(
-                    ipv4_address, ixn_ip, Ethernet._GATEWAY_MAC
+            if self._ngpf.is_ip_allowed == False:
+                ixn_ip = None
+                self._ngpf.set_device_info(ipv4_address, ixn_ip)
+            else:
+                ixn_ip = self.create_node_elemet(
+                    ixn_eth, "ipv4", ipv4_address.get("name")
                 )
+                self._ngpf.set_device_info(ipv4_address, ixn_ip)
+                self.configure_multivalues(ipv4_address, ixn_ip, Ethernet._IP)
+                if ipv4_address.gateway_mac.choice == "value":
+                    self.configure_multivalues_with_choice(
+                        ipv4_address, ixn_ip, Ethernet._GATEWAY_MAC
+                    )
 
     def _configure_ipv6(self, ixn_eth, ethernet):
         self.logger.debug("Configuring IPv6 interface")
         ipv6_addresses = ethernet.get("ipv6_addresses")
         if ipv6_addresses is None:
-            return
-        if self._ngpf.is_ip_allowed == False:
-            self.logger.debug("Skip IPv6 configuration")
             return
 
         eth_name = ethernet.name
@@ -100,12 +98,16 @@ class Ethernet(Base):
             self._ngpf.ether_v6gateway_map[eth_name].append(
                 ipv6_address.gateway
             )
-            ixn_ip = self.create_node_elemet(
-                ixn_eth, "ipv6", ipv6_address.get("name")
-            )
-            self._ngpf.set_device_info(ipv6_address, ixn_ip)
-            self.configure_multivalues(ipv6_address, ixn_ip, Ethernet._IP)
-            if ipv6_address.gateway_mac.choice == "value":
-                self.configure_multivalues_with_choice(
-                    ipv6_address, ixn_ip, Ethernet._GATEWAY_MAC
+            if self._ngpf.is_ip_allowed == False:
+                ixn_ip = None
+                self._ngpf.set_device_info(ipv6_address, ixn_ip)
+            else:
+                ixn_ip = self.create_node_elemet(
+                    ixn_eth, "ipv6", ipv6_address.get("name")
                 )
+                self._ngpf.set_device_info(ipv6_address, ixn_ip)
+                self.configure_multivalues(ipv6_address, ixn_ip, Ethernet._IP)
+                if ipv6_address.gateway_mac.choice == "value":
+                    self.configure_multivalues_with_choice(
+                        ipv6_address, ixn_ip, Ethernet._GATEWAY_MAC
+                    )

--- a/snappi_ixnetwork/device/macsec.py
+++ b/snappi_ixnetwork/device/macsec.py
@@ -307,9 +307,12 @@ class Macsec(Base):
         ethernets = device.get("ethernets")
         for ethernet in ethernets:
             if ethernet.get("name") == ethernet_name:
+                self._ngpf.api.set_device_traffic_endpoint(ethernet_name, secy.get("name"))
                 ipv4_addresses = ethernet.get("ipv4_addresses")
                 if ipv4_addresses is None:
-                    raise Exception("IPv4 not configured on ethernet %s" % ethernet_name)
+                    #raise Exception("IPv4 not configured on ethernet %s" % ethernet_name)
+                    self.logger.info("IPv4 not configured on ethernet %s" % ethernet_name)
+                    break
                 elif len(ipv4_addresses) > 1:
                     raise Exception("More than one IPv4 address configured on ethernet %s" % ethernet_name)
                 ipv4_address = ipv4_addresses[0].address
@@ -321,6 +324,7 @@ class Macsec(Base):
                 ipv4_gateway_static_mac = ipv4_addresses[0].gateway_mac.value
                 ixn_staticmacsec["sourceIp"] = self.multivalue(ipv4_address)
                 ixn_staticmacsec["dutMac"] = self.multivalue(ipv4_gateway_static_mac)
+                self._ngpf.api.set_device_traffic_endpoint(ipv4_addresses[0].name, secy.get("name"))
                 break
 
     def _config_crypto_engine_encrypt_only_tx_pn(self, secy, ixn_staticmacsec):

--- a/snappi_ixnetwork/snappi_api.py
+++ b/snappi_ixnetwork/snappi_api.py
@@ -86,6 +86,7 @@ class Api(snappi.Api):
         self._assistant = None
         self._ixn_errors = list()
         self._config_objects = {}
+        self._device_traffic_endpoint = {}
         self._device_encap = {}
         self.ixn_objects = None
         self._config_type = self.config()
@@ -157,6 +158,16 @@ class Api(snappi.Api):
 
     def set_device_encap(self, name, type):
         self._device_encap[name] = type
+
+    def get_device_traffic_endpoint(self, name):
+        try:
+            value = self._device_traffic_endpoint[name]
+        except KeyError:
+            value = None
+        return value
+
+    def set_device_traffic_endpoint(self, name, value):
+        self._device_traffic_endpoint[name] = value
 
     @property
     def username(self):
@@ -333,6 +344,7 @@ class Api(snappi.Api):
     def config_ixnetwork(self, config):
         self._config_objects = {}
         self._device_encap = {}
+        self._device_traffic_endpoint = {}
         self.ixn_objects = IxNetObjects(self)
         self.ixn_routes = IxNetObjects(self)
         self._dev_compacted = {}

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -494,7 +494,10 @@ class TrafficItem(CustomField):
             return {}
         paths = {}
         for i, dev_name in enumerate(dev_names):
-            paths[dev_name] = {"dev_info": self._api.ixn_objects.get(dev_name)}
+            traffic_endpoint_dev_name = self._api.get_device_traffic_endpoint(dev_name)
+            if traffic_endpoint_dev_name is None:
+               traffic_endpoint_dev_name = dev_name
+            paths[dev_name] = {"dev_info": self._api.ixn_objects.get(traffic_endpoint_dev_name)}
             paths[dev_name]["type"] = self._api.get_device_encap(dev_name)
         self.logger.debug("Device Information : %s" % paths)
         return paths

--- a/tests/macsec/test_macsec_mka_traffic.py
+++ b/tests/macsec/test_macsec_mka_traffic.py
@@ -128,11 +128,22 @@ def test_encrypt_with_mka(api, b2b_raw_config, utils):
     ip2.gateway_mac.choice = "value"
     ip2.gateway_mac.value = eth1.mac
 
-    #traffic
+    # Flow
     f1 = config.flows.flow(name="f1")[-1]
-    f1.tx_rx.device.tx_names = [secy1.name]
-    f1.tx_rx.device.rx_names = [secy2.name]
-    f1.packet.ethernet()
+
+    # Ethernet/VLAN traffic from secY to secY endpoints
+    #f1.tx_rx.device.tx_names = [secy1.name]
+    #f1.tx_rx.device.rx_names = [secy2.name]
+
+    # Ethernet/VLAN traffic from ethernet to ethernet endpoints
+    #f1.tx_rx.device.tx_names = [eth1.name]
+    #f1.tx_rx.device.rx_names = [eth2.name]
+
+    # IPv4 traffic from IP to IP endpoints
+    f1.tx_rx.device.tx_names = [ip1.name]
+    f1.tx_rx.device.rx_names = [ip2.name]
+
+    # Rate
     f1.rate.pps = 10
 
     utils.start_traffic(api, config)


### PR DESCRIPTION
Any MACsec traffic is of type ethernet/VLAN type now. The encapsulation type is "Ethernet.MACsec" in traffic. As a result, "Ethernet.MACsec.PayloadProtocolType.IPv4" encapsuation is not set and IPv4 traffic cannot be sent. 

The PR lets traffic endpoints (IPv4/ Ethernet) decide MACsec traffic type(IPv4 or ethernet/VLAN) and not default ethernet/VLAN encapsulation property of MACsec SecureEntity device. This approach should work for future MACsec variant "encrypt_decrypt" also.