### PR TITLE
Change MACsec metric name and test scripts

### DIFF
--- a/snappi_ixnetwork/protocolmetrics.py
+++ b/snappi_ixnetwork/protocolmetrics.py
@@ -59,7 +59,7 @@ class ProtocolMetrics(object):
             ("out_pkts_protected", "Protected Packet Tx", int),
             ("out_pkts_encrypted", "Encrypted Packet Tx", int),
             ("in_pkts_ok", "Valid Packet Rx", int),
-            ("bad_pkts_rx", "Bad Packet Rx", int),
+            ("in_pkts_bad", "Total number of bad Packet Rx", int),
             ("in_pkts_bad_tag", "Bad Tag/ICV Discarded", int),
             ("in_pkts_late", "Out of Window Discarded", int),
             ("in_pkts_no_sci", "Unknown SCI Discarded", int),

--- a/tests/macsec/test_macsec_mka_traffic.py
+++ b/tests/macsec/test_macsec_mka_traffic.py
@@ -40,13 +40,17 @@ def test_encrypt_with_mka(api, b2b_raw_config, utils):
     secy1.data_plane.choice = secy2.data_plane.choice = "encapsulation"
     secy1.data_plane.encapsulation.crypto_engine.choice = secy2.data_plane.encapsulation.crypto_engine.choice = "encrypt_only"
     secy1_crypto_engine_enc_only, secy2_crypto_engine_enc_only = secy1.data_plane.encapsulation.crypto_engine.encrypt_only, secy2.data_plane.encapsulation.crypto_engine.encrypt_only 
- 
-    # Data plane Tx SC PN 
-    secy1_dataplane_txsc1, secy2_dataplane_txsc1 = secy1_crypto_engine_enc_only.secure_channels.add(), secy2_crypto_engine_enc_only.secure_channels.add()
-    secy1_dataplane_txsc1.tx_pn.choice = secy2_dataplane_txsc1.tx_pn.choice = "incrementing_pn"
 
-    secy1_dataplane_txsc1.tx_pn.incrementing.starting_pn = secy2_dataplane_txsc1.tx_pn.incrementing.starting_pn = 1
-    secy1_dataplane_txsc1.tx_pn.incrementing.count = secy2_dataplane_txsc1.tx_pn.incrementing.count = 10000
+    # Data plane Tx SC
+    secy1_dataplane_txsc1, secy2_dataplane_txsc1 = secy1_crypto_engine_enc_only.secure_channels.add(), secy2_crypto_engine_enc_only.secure_channels.add()
+
+    # Fixed PN
+    secy1_dataplane_txsc1.tx_pn.choice = secy2_dataplane_txsc1.tx_pn.choice = "fixed_pn"
+ 
+    # OR incrementing PN
+    #secy1_dataplane_txsc1.tx_pn.choice = secy2_dataplane_txsc1.tx_pn.choice = "incrementing_pn"
+    #secy1_dataplane_txsc1.tx_pn.incrementing.starting_pn = secy2_dataplane_txsc1.tx_pn.incrementing.starting_pn = 1
+    #secy1_dataplane_txsc1.tx_pn.incrementing.count = secy2_dataplane_txsc1.tx_pn.incrementing.count = 10000
 
     ####################
     # MKA
@@ -211,7 +215,7 @@ def test_encrypt_with_mka(api, b2b_raw_config, utils):
         "out_pkts_protected",
         "out_pkts_encrypted",
         "in_pkts_ok",
-        "bad_pkts_rx",
+        "in_pkts_bad",
         "in_pkts_bad_tag",
         "in_pkts_late",
         "in_pkts_no_sci",

--- a/tests/macsec/test_macsec_stats.py
+++ b/tests/macsec/test_macsec_stats.py
@@ -103,7 +103,7 @@ def test_encrypt(api, b2b_raw_config, utils):
         "out_pkts_protected",
         "out_pkts_encrypted",
         "in_pkts_ok",
-        "bad_pkts_rx",
+        "in_pkts_bad",
         "in_pkts_bad_tag",
         "in_pkts_late",
         "in_pkts_no_sci",


### PR DESCRIPTION
Change metric name from bad_pkts_rx to in_pkts_bad. Also change Tx PN from incremeneting choice to fixed choice as incrementing PN fails traffic apply on some cards due to insufficient UDF resource.