### PR TITLE
Egress only tracking support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     install_requires=["ixnetwork-restpy>=1.0.52"],
     extras_require={
         "testing": [
-            "snappi==1.27.1",
+            "snappi==1.30.0",
             "pytest",
             "mock",
             "dpkt==1.9.4",

--- a/snappi_ixnetwork/snappi_api.py
+++ b/snappi_ixnetwork/snappi_api.py
@@ -562,6 +562,11 @@ class Api(snappi.Api):
                 metric_res = self.metrics_response()
                 metric_res.flow_metrics.deserialize(response)
                 return metric_res
+            if request.get("choice") == "egress_only_tracking":
+                response = self.traffic_item.results_egress_only_tracking(request.egress_only_tracking)
+                metric_res = self.metrics_response()
+                metric_res.egress_only_tracking_metrics.deserialize(response)
+                return metric_res
             if request.get("choice") == "lag":
                 response = self.traffic_item.results(request.lag)
                 metric_res = self.metrics_response()

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -721,7 +721,8 @@ class TrafficItem(CustomField):
             )
 
         # egress only tracking
-        tr["egressOnlyTracking"] = []
+        if len(config.egress_only_tracking) > 0:
+            tr["egressOnlyTracking"] = []
         for snappi_eotr in config.egress_only_tracking:
             eotr_port_name = snappi_eotr.port_name
             eotr_xpath = "/traffic/egressOnlyTracking[%d]" % self.egress_only_tracking_index

--- a/snappi_ixnetwork/trafficitem.py
+++ b/snappi_ixnetwork/trafficitem.py
@@ -737,7 +737,7 @@ class TrafficItem(CustomField):
                     per_port_mt_dict_result["metric_tags"].append(mt_dict_entry_result)
                 else:
                     raise ValueError(
-                        "%s metric tag %s length error" % snappi_mt.name
+                        "%s metric tag has length error" % snappi_mt.name
                     )
                 mt_index += 1
             if len(per_port_mt_dict_result["metric_tags"]) > 0:
@@ -1781,7 +1781,7 @@ class TrafficItem(CustomField):
                 and
                 self.port_egress_only_tracking[port_rx] is not None
             ):
-                if int(row["Rx Frames"]) == 0 and include_empty_metrics is False:
+                if include_empty_metrics is False and int(row["Tx Frames"]) == 0 and int(row["Rx Frames"]) == 0:
                     # skip empty row
                     continue
                 result_flow_row = None

--- a/tests/macsec/test_macsec_mka_traffic.py
+++ b/tests/macsec/test_macsec_mka_traffic.py
@@ -164,6 +164,21 @@ def test_encrypt_with_mka(api, b2b_raw_config, utils):
     # Rate
     f1.rate.pps = 10
 
+    # egress only tracking(eotr)
+    eotrs = config.egress_only_trackings
+    eotr1 = eotrs.add()
+    eotr1.port_name = p2.name
+
+    # eotr filter
+    eotr1_filter1 = eotr1.filters.add()
+    eotr1_filter1 = "auto_macsec"
+
+    # eotr metric tag for destination MAC 3rd byte from MSB: LS 4 bits
+    eotr1_mt1 = eotr1.metric_tags.add()
+    eotr1_mt1.name = "dest_mac_addr"
+    eotr1_mt1.offset = 24
+    eotr1_mt1.length = 8
+
     utils.start_traffic(api, config)
 
     ####################


### PR DESCRIPTION
Feature description
==============
Egress only tracking support to track flow statistics per tracked bits (say count = M) at given offset (say N bits) from start of Rx packet.

Use Cases
=========
Flow can be tracked using MAC address or VLAN ID.


Added TCs
=========
Test cases added in MACsec to do egress tracking based on destination MAC address bits