### PR TITLE
Support for Tx offset adjustment in egress only tracking

### DIFF
--- a/tests/macsec/test_macsec_mka_traffic.py
+++ b/tests/macsec/test_macsec_mka_traffic.py
@@ -176,12 +176,12 @@ def test_encrypt_with_mka(api, b2b_raw_config, utils):
     # eotr metric tag for destination MAC 3rd byte from MSB: LS 4 bits
     eotr1_mt1 = eotr1.metric_tags.add()
     eotr1_mt1.name = "dest_mac_addr"
-    eotr1_mt1.offset = 29
+    eotr1_mt1.rx_offset = 29
     eotr1_mt1.length = 3
 
     #eotr1_mt2 = eotr1.metric_tags.add()
     #eotr1_mt2.name = "macsec_sci"
-    #eotr1_mt2.offset = 189
+    #eotr1_mt2.rx_offset = 189
     #eotr1_mt2.length = 3
 
     utils.start_traffic(api, config)


### PR DESCRIPTION
Feature description:
=============

In egress only tracking settings for implementations that support Tx statistics, support for "Tx offset" setting is added to cover cases where Rx/ Tx offsets of tracked field are not same. This change is required to associate Tx/ Rx statistics with the same value of a tracked field in egress only tracking result. Tx offset can have three type of values:

Use-cases:
=======

A.	DUT does not add or strip any more header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 31) --->DUT (does not add or strip e.g. MACsec header)---->Rx (offset of IP DSCP = 31)

        This is for a case where Tx offset of a tracked field is same as Rx (egress) side – DUT does not change offset of tracked field.

B.	DUT adds encapsulation header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 17) --->DUT (adds e.g. MACsec header of size 14 bytes) ---->Rx (offset of IP DSCP = 31)

        This is for a case where Rx (egress) offset of a tracked field is higher than that at Tx side

C.	DUT strips encapsulation header (e.g. MACsec) above tracked field in packet

        Tx (offset of IP DSCP = 31) --->DUT (strips e.g. MACsec header of size 14 bytes) ---->Rx (offset of IP DSCP = 17)

        This is for a case where Rx (egress) offset of a tracked field is lower than that at Tx side

TCs with brief description
=================

For use case similar to A) above: ~/tests/macsec/test_macsec_mka_traffic.py:

     # eotr metric tag for destination MAC 3rd byte from MSB: LS 4 bits
     eotr1_mt1 = eotr1.metric_tags.add()
     eotr1_mt1.name = "dest_mac_addr"
     eotr1_mt1.rx_offset = 29
     eotr1_mt1.length = 3

For use case B) above:

     eotr1_mt1.rx_offset = 31
     eotr1_mt1.tx_offset.choice = "custom"
     eotr1_mt1.tx_offset.custom.value = 17

For use case  C) above:

     eotr1_mt1.rx_offset = 17
     eotr1_mt1.tx_offset.choice = "custom"
     eotr1_mt1.tx_offset.custom.value = 31