### PR TITLE
Support get_states with bgp_prefixes (BGP learned-route retrieval)

### DIFF
--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -337,15 +337,17 @@ class Bgp(Base):
 
     # Column-name aliases tried in order (first hit wins).  IxNetwork has
     # varied slightly across versions; this covers the known variants.
-    _V4_ADDR_COLS    = ("IPv4 Prefix", "IP Address",  "Network Address", "Network", "Network Prefix")
+    _V4_ADDR_COLS    = ("IPv4 Prefix",)
     _V6_ADDR_COLS    = ("IPv6 Address", "IPv6 Prefix", "IP Address", "Network Address", "Network")
-    _NLRI_COLS       = ("NLRI", "Prefix Length", "Prefix")
+    _NLRI_COLS       = ("Prefix Length",)
     _NH_COLS         = ("Next Hop",    "NextHop",   "Next-Hop")
+    _V4_NH_COLS      = ("IPv4 Next Hop",)
+    _V6_NH_COLS      = ("Ipv6 Next Hop",)
     _ORIGIN_COLS     = ("Origin",)
-    _LOCPREF_COLS    = ("Local Pref",  "LocalPref", "Local Preference")
+    _LOCPREF_COLS    = ("Local Preference", "Local Pref", "LocalPref")
     _MED_COLS        = ("MED",         "Multi Exit Discriminator")
     _ASPATH_COLS     = ("AS Path",     "AS-Path",   "AsPath")
-    _COMMUNITY_COLS  = ("Communities", "Community")
+    _COMMUNITY_COLS  = ("Community",   "Communities")
     _PATHID_COLS     = ("Path ID",     "PathId",    "Add Path ID")
 
     def get_bgp_peer_objects(self, peer_names):
@@ -477,13 +479,13 @@ class Bgp(Base):
                     columns = table.Columns
                     if not columns:
                         continue
-                    self.logger.warning(
-                        "_get_learned_table: peer=%r Type=%r "
-                        "Columns=%r RowCount=%d"
-                        % (peer_obj.Name, table.Type,
-                           columns, len(table.Values or []))
-                    )
-                    col_idx = {col: i for i, col in enumerate(columns)}
+                    # self.logger.warning(
+                    #     "_get_learned_table: peer=%r Type=%r "
+                    #     "Columns=%r RowCount=%d"
+                    #     % (peer_obj.Name, table.Type,
+                    #        columns, len(table.Values or []))
+                    # )
+                    col_idx = {col.strip(): i for i, col in enumerate(columns)}
                     for row_vals in (table.Values or []):
                         rows.append({
                             col: row_vals[i]
@@ -495,11 +497,6 @@ class Bgp(Base):
                 "_get_learned_table: Table.find() failed for peer %r: %s"
                 % (peer_obj.Name, e)
             )
-
-        self.logger.warning(
-            "_get_learned_table: peer=%r family=%s total_rows=%d"
-            % (peer_obj.Name, family, len(rows))
-        )
         return rows
 
     # --- static low-level helpers ------------------------------------
@@ -551,13 +548,15 @@ class Bgp(Base):
         token = cell.strip()
         while i < len(token):
             ch = token[i]
-            if ch in ("{", "(", "["):
-                close = {"{"  : "}",
-                         "("  : ")",
-                         "["  : "]"}[ch]
-                seg_type = {"{"  : "as_set",
-                            "("  : "as_confed_seq",
-                            "["  : "as_confed_set"}[ch]
+            if ch in ("{", "(", "[", "<"):
+                close = {"{": "}",
+                         "(": ")",
+                         "[": "]",
+                         "<": ">"}[ch]
+                seg_type = {"{": "as_set",
+                            "(": "as_confed_seq",
+                            "[": "as_confed_set",
+                            "<": "as_seq"}[ch]
                 _flush_seq()
                 end = token.find(close, i + 1)
                 inner = token[i + 1 : end if end != -1 else len(token)]
@@ -567,7 +566,7 @@ class Bgp(Base):
             else:
                 # Collect plain ASNs up to the next group delimiter
                 next_group = len(token)
-                for delim in ("{", "(", "["):
+                for delim in ("{", "(", "[", "<"):
                     pos = token.find(delim, i)
                     if pos != -1 and pos < next_group:
                         next_group = pos
@@ -592,16 +591,21 @@ class Bgp(Base):
         if not cell or cell.strip().lower() in ("", "n/a"):
             return []
 
+        # IxNetwork sometimes emits spaces around the colon, e.g. "1 : 2".
+        # Normalise to "1:2" before tokenising.
+        import re
+        cell = re.sub(r'\s*:\s*', ':', cell)
+
         _WELL_KNOWN = {
-            "no-export"           : "no_export",
-            "noexport"            : "no_export",
-            "no-advertise"        : "no_advertised",
-            "noadvertise"         : "no_advertised",
-            "no-advertised"       : "no_advertised",
-            "no_export_subconfed" : "no_export_subconfed",
-            "no-export-subconfed" : "no_export_subconfed",
-            "llgr_stale"          : "llgr_stale",
-            "no_llgr"             : "no_llgr",
+            "no-export": "no_export",
+            "noexport": "no_export",
+            "no-advertise": "no_advertised",
+            "noadvertise": "no_advertised",
+            "no-advertised": "no_advertised",
+            "no_export_subconfed": "no_export_subconfed",
+            "no-export-subconfed": "no_export_subconfed",
+            "llgr_stale": "llgr_stale",
+            "no_llgr": "no_llgr",
         }
 
         result = []
@@ -613,17 +617,17 @@ class Bgp(Base):
                 parts = token.split(":", 1)
                 try:
                     result.append({
-                        "type"      : "manual_as_number",
-                        "as_number" : int(parts[0]),
-                        "as_custom" : int(parts[1]),
+                        "type": "manual_as_number",
+                        "as_number": int(parts[0]),
+                        "as_custom": int(parts[1]),
                     })
                 except (ValueError, IndexError):
                     self.logger.warning(
-                        "Skipping unrecognised community token: %s" % token
+                        "1. Skipping unrecognised community token: %s" % token
                     )
             else:
                 self.logger.warning(
-                    "Skipping unrecognised community token: %s" % token
+                    "2. Skipping unrecognised community token: %s" % token
                 )
         return result
 
@@ -644,27 +648,30 @@ class Bgp(Base):
         # Some IxN versions emit a full CIDR in the address column.
         if "/" in addr_cell:
             parts = addr_cell.split("/", 1)
-            ipv4_address  = parts[0]
+            ipv4_address = parts[0]
             prefix_length = self._safe_int(parts[1])
         else:
-            ipv4_address  = addr_cell
+            ipv4_address = addr_cell
             prefix_length = self._safe_int(nlri_cell)
 
-        nh_cell = self._get_cell(row, *self._NH_COLS) or ""
-        # Route next-hops that contain ":" are IPv6-mapped next-hops.
-        ipv4_nh = nh_cell if ":" not in nh_cell else None
-        ipv6_nh = nh_cell if ":" in nh_cell else None
+        ipv4_nh = self._get_cell(row, *self._V4_NH_COLS) or None
+        ipv6_nh = self._get_cell(row, *self._V6_NH_COLS) or None
+        # Fall back to legacy single next-hop column, using ":" to distinguish.
+        if ipv4_nh is None and ipv6_nh is None:
+            nh_cell = self._get_cell(row, *self._NH_COLS) or ""
+            ipv4_nh = nh_cell if nh_cell and ":" not in nh_cell else None
+            ipv6_nh = nh_cell if ":" in nh_cell else None
 
         origin_raw = self._get_cell(row, *self._ORIGIN_COLS) or ""
         origin = self._IXN_ORIGIN_MAP.get(origin_raw.lower())
 
         prefix = {
-            "ipv4_address"            : ipv4_address,
-            "prefix_length"           : prefix_length,
-            "as_path"                 : self._parse_as_path(
+            "ipv4_address": ipv4_address,
+            "prefix_length": prefix_length,
+            "as_path": self._parse_as_path(
                 self._get_cell(row, *self._ASPATH_COLS)
             ),
-            "communities"             : self._parse_communities(
+            "communities": self._parse_communities(
                 self._get_cell(row, *self._COMMUNITY_COLS)
             ),
         }
@@ -848,8 +855,6 @@ class Bgp(Base):
                 if bgp_prefix_request is not None
                 else None
             )
-            print("Prefixes before filter: ", prefixes)
-            print("Filters: ", filters)
             return self._apply_v4_filters(prefixes, filters)
         else:
             prefixes = [

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -303,6 +303,30 @@ class Bgp(Base):
     # Learned-info helpers (used by ngpf.get_bgp_prefix_states)
     # ------------------------------------------------------------------
 
+    # IxNetwork single-char origin → OTG origin string
+    _IXN_ORIGIN_MAP = {
+        "i": "igp",
+        "e": "egp",
+        "?": "incomplete",
+        # accept long-form in case a future IxN version emits them
+        "igp": "igp",
+        "egp": "egp",
+        "incomplete": "incomplete",
+    }
+
+    # Column-name aliases tried in order (first hit wins).  IxNetwork has
+    # varied slightly across versions; this covers the known variants.
+    _V4_ADDR_COLS    = ("IP Address",  "Network Address", "Network")
+    _V6_ADDR_COLS    = ("IPv6 Address", "IP Address", "Network Address", "Network")
+    _NLRI_COLS       = ("NLRI", "Prefix Length", "Prefix")
+    _NH_COLS         = ("Next Hop",    "NextHop",   "Next-Hop")
+    _ORIGIN_COLS     = ("Origin",)
+    _LOCPREF_COLS    = ("Local Pref",  "LocalPref", "Local Preference")
+    _MED_COLS        = ("MED",         "Multi Exit Discriminator")
+    _ASPATH_COLS     = ("AS Path",     "AS-Path",   "AsPath")
+    _COMMUNITY_COLS  = ("Communities", "Community")
+    _PATHID_COLS     = ("Path ID",     "PathId",    "Add Path ID")
+
     def get_bgp_peer_objects(self, peer_names):
         """Return a list of ``(peer_name, restpy_peer_obj, session_index,
         family)`` for every BGP peer that matches *peer_names*.
@@ -439,6 +463,365 @@ class Bgp(Base):
                     }
                     rows.append(row)
         return rows
+
+    # --- static low-level helpers ------------------------------------
+
+    @staticmethod
+    def _get_cell(row, *col_names):
+        """Return the stripped value of the first matching column in *row*,
+        or ``None`` if none of the candidate column names are present."""
+        for name in col_names:
+            val = row.get(name)
+            if val is not None:
+                return val.strip()
+        return None
+
+    @staticmethod
+    def _safe_int(s, default=0):
+        """Convert *s* to ``int``; return *default* on failure."""
+        try:
+            return int(s)
+        except (TypeError, ValueError):
+            return default
+
+    # --- AS-path / community parsers ---------------------------------
+
+    def _parse_as_path(self, cell):
+        """Convert an IxNetwork AS-path string to an OTG ``as_path`` dict.
+
+        Supported input formats::
+
+            "100 200 300"      → single AS_SEQ segment
+            "{100 200} 300"    → AS_SET [100,200] then AS_SEQ [300]
+            "(100 200)"        → AS_CONFED_SEQ segment
+            "[100 200]"        → AS_CONFED_SET segment
+            ""  / "N/A" / "0"  → empty segments list
+        """
+        if not cell or cell.strip().lower() in ("", "n/a", "0"):
+            return {"segments": []}
+
+        segments = []
+        seq_buf = []   # accumulates plain ASNs for the current AS_SEQ
+
+        def _flush_seq():
+            if seq_buf:
+                segments.append({"type": "as_seq",
+                                  "as_numbers": list(seq_buf)})
+                seq_buf.clear()
+
+        i = 0
+        token = cell.strip()
+        while i < len(token):
+            ch = token[i]
+            if ch in ("{", "(", "["):
+                close = {"{"  : "}",
+                         "("  : ")",
+                         "["  : "]"}[ch]
+                seg_type = {"{"  : "as_set",
+                            "("  : "as_confed_seq",
+                            "["  : "as_confed_set"}[ch]
+                _flush_seq()
+                end = token.find(close, i + 1)
+                inner = token[i + 1 : end if end != -1 else len(token)]
+                asns = [int(x) for x in inner.split() if x.isdigit()]
+                segments.append({"type": seg_type, "as_numbers": asns})
+                i = (end + 1) if end != -1 else len(token)
+            else:
+                # Collect plain ASNs up to the next group delimiter
+                next_group = len(token)
+                for delim in ("{", "(", "["):
+                    pos = token.find(delim, i)
+                    if pos != -1 and pos < next_group:
+                        next_group = pos
+                for part in token[i:next_group].split():
+                    if part.isdigit():
+                        seq_buf.append(int(part))
+                i = next_group
+
+        _flush_seq()
+        return {"segments": segments}
+
+    def _parse_communities(self, cell):
+        """Convert an IxNetwork communities string to a list of OTG dicts.
+
+        Handled formats::
+
+            "1:2 3:4"      → two ``manual_as_number`` entries
+            "no-export"    → ``no_export`` well-known entry
+            "no-advertise" → ``no_advertised`` well-known entry
+            "" / "N/A"     → empty list
+        """
+        if not cell or cell.strip().lower() in ("", "n/a"):
+            return []
+
+        _WELL_KNOWN = {
+            "no-export"           : "no_export",
+            "noexport"            : "no_export",
+            "no-advertise"        : "no_advertised",
+            "noadvertise"         : "no_advertised",
+            "no-advertised"       : "no_advertised",
+            "no_export_subconfed" : "no_export_subconfed",
+            "no-export-subconfed" : "no_export_subconfed",
+            "llgr_stale"          : "llgr_stale",
+            "no_llgr"             : "no_llgr",
+        }
+
+        result = []
+        for token in cell.split():
+            lower = token.lower()
+            if lower in _WELL_KNOWN:
+                result.append({"type": _WELL_KNOWN[lower]})
+            elif ":" in token:
+                parts = token.split(":", 1)
+                try:
+                    result.append({
+                        "type"      : "manual_as_number",
+                        "as_number" : int(parts[0]),
+                        "as_custom" : int(parts[1]),
+                    })
+                except (ValueError, IndexError):
+                    self.logger.warning(
+                        "Skipping unrecognised community token: %s" % token
+                    )
+            else:
+                self.logger.warning(
+                    "Skipping unrecognised community token: %s" % token
+                )
+        return result
+
+    # --- row → OTG prefix dict ---------------------------------------
+
+    def _row_to_ipv4_prefix(self, row):
+        """Convert a raw IxNetwork row dict to an OTG IPv4 unicast prefix dict.
+
+        Returns ``None`` when the row lacks address information (e.g. it
+        belongs to a different table type such as IPv4 MPLS).
+        """
+        addr_cell = self._get_cell(row, *self._V4_ADDR_COLS)
+        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
+
+        if not addr_cell:
+            return None
+
+        # Some IxN versions emit a full CIDR in the address column.
+        if "/" in addr_cell:
+            parts = addr_cell.split("/", 1)
+            ipv4_address  = parts[0]
+            prefix_length = self._safe_int(parts[1])
+        else:
+            ipv4_address  = addr_cell
+            prefix_length = self._safe_int(nlri_cell)
+
+        nh_cell = self._get_cell(row, *self._NH_COLS) or ""
+        # Route next-hops that contain ":" are IPv6-mapped next-hops.
+        ipv4_nh = nh_cell if ":" not in nh_cell else None
+        ipv6_nh = nh_cell if ":" in nh_cell else None
+
+        origin_raw = self._get_cell(row, *self._ORIGIN_COLS) or ""
+        origin = self._IXN_ORIGIN_MAP.get(origin_raw.lower())
+
+        prefix = {
+            "ipv4_address"            : ipv4_address,
+            "prefix_length"           : prefix_length,
+            "as_path"                 : self._parse_as_path(
+                self._get_cell(row, *self._ASPATH_COLS)
+            ),
+            "communities"             : self._parse_communities(
+                self._get_cell(row, *self._COMMUNITY_COLS)
+            ),
+        }
+        if origin:
+            prefix["origin"] = origin
+        if ipv4_nh:
+            prefix["ipv4_next_hop"] = ipv4_nh
+        if ipv6_nh:
+            prefix["ipv6_next_hop"] = ipv6_nh
+
+        locpref_val = self._get_cell(row, *self._LOCPREF_COLS)
+        if locpref_val not in (None, "", "N/A"):
+            prefix["local_preference"] = self._safe_int(locpref_val)
+
+        med_val = self._get_cell(row, *self._MED_COLS)
+        if med_val not in (None, "", "N/A"):
+            prefix["multi_exit_discriminator"] = self._safe_int(med_val)
+
+        pid_val = self._get_cell(row, *self._PATHID_COLS)
+        if pid_val not in (None, "", "N/A", "0"):
+            prefix["path_id"] = self._safe_int(pid_val)
+
+        return prefix
+
+    def _row_to_ipv6_prefix(self, row):
+        """Convert a raw IxNetwork row dict to an OTG IPv6 unicast prefix dict.
+
+        Returns ``None`` when the row lacks address information.
+        """
+        addr_cell = self._get_cell(row, *self._V6_ADDR_COLS)
+        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
+
+        if not addr_cell:
+            return None
+
+        if "/" in addr_cell:
+            parts = addr_cell.split("/", 1)
+            ipv6_address  = parts[0]
+            prefix_length = self._safe_int(parts[1])
+        else:
+            ipv6_address  = addr_cell
+            prefix_length = self._safe_int(nlri_cell)
+
+        nh_cell = self._get_cell(row, *self._NH_COLS) or ""
+        ipv6_nh = nh_cell if ":" in nh_cell else None
+        ipv4_nh = nh_cell if ":" not in nh_cell and nh_cell else None
+
+        origin_raw = self._get_cell(row, *self._ORIGIN_COLS) or ""
+        origin = self._IXN_ORIGIN_MAP.get(origin_raw.lower())
+
+        prefix = {
+            "ipv6_address"  : ipv6_address,
+            "prefix_length" : prefix_length,
+            "as_path"       : self._parse_as_path(
+                self._get_cell(row, *self._ASPATH_COLS)
+            ),
+            "communities"   : self._parse_communities(
+                self._get_cell(row, *self._COMMUNITY_COLS)
+            ),
+        }
+        if origin:
+            prefix["origin"] = origin
+        if ipv6_nh:
+            prefix["ipv6_next_hop"] = ipv6_nh
+        if ipv4_nh:
+            prefix["ipv4_next_hop"] = ipv4_nh
+
+        locpref_val = self._get_cell(row, *self._LOCPREF_COLS)
+        if locpref_val not in (None, "", "N/A"):
+            prefix["local_preference"] = self._safe_int(locpref_val)
+
+        med_val = self._get_cell(row, *self._MED_COLS)
+        if med_val not in (None, "", "N/A"):
+            prefix["multi_exit_discriminator"] = self._safe_int(med_val)
+
+        pid_val = self._get_cell(row, *self._PATHID_COLS)
+        if pid_val not in (None, "", "N/A", "0"):
+            prefix["path_id"] = self._safe_int(pid_val)
+
+        return prefix
+
+    # --- filter application ------------------------------------------
+
+    @staticmethod
+    def _prefix_matches_filter(prefix, filt, addr_key):
+        """Return True if *prefix* satisfies all non-None fields of *filt*.
+
+        Missing / None filter fields are treated as wildcards (match all).
+        """
+        addresses = filt.addresses
+        if addresses:
+            if prefix.get(addr_key) not in addresses:
+                return False
+
+        prefix_length = filt.prefix_length
+        if prefix_length is not None:
+            if prefix.get("prefix_length") != prefix_length:
+                return False
+
+        origin = filt.origin
+        if origin is not None:
+            if prefix.get("origin") != origin:
+                return False
+
+        path_id = filt.path_id
+        if path_id is not None:
+            if prefix.get("path_id", 0) != path_id:
+                return False
+
+        return True
+
+    def _apply_v4_filters(self, prefixes, filters):
+        """Return prefixes that match at least one IPv4 unicast filter.
+
+        An empty *filters* list (or ``None``) means no restriction: all
+        prefixes are returned.  Multiple filters are OR-ed; within each
+        filter, fields are AND-ed.
+        """
+        if not filters:
+            return prefixes
+        return [
+            p for p in prefixes
+            if any(
+                self._prefix_matches_filter(p, f, "ipv4_address")
+                for f in filters
+            )
+        ]
+
+    def _apply_v6_filters(self, prefixes, filters):
+        """Return prefixes that match at least one IPv6 unicast filter.
+
+        Semantics identical to :meth:`_apply_v4_filters`.
+        """
+        if not filters:
+            return prefixes
+        return [
+            p for p in prefixes
+            if any(
+                self._prefix_matches_filter(p, f, "ipv6_address")
+                for f in filters
+            )
+        ]
+
+    # --- public orchestrator -----------------------------------------
+
+    def get_learned_prefixes(self, peer_obj, session_index, family,
+                             bgp_prefix_request):
+        """Fetch and translate learned prefixes for one peer session.
+
+        Calls :meth:`_get_learned_table` to retrieve raw IxNetwork rows,
+        converts each row to an OTG prefix dict, then applies any
+        unicast filters present in *bgp_prefix_request*.
+
+        Parameters
+        ----------
+        peer_obj :
+            Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
+        session_index : int
+            1-based session index (from :meth:`get_bgp_peer_objects`).
+        family : str
+            ``"v4"`` or ``"v6"``.
+        bgp_prefix_request :
+            Snappi ``BgpPrefixStateRequest`` (``request.bgp_prefixes``).
+            May be ``None`` when called without filter context.
+
+        Returns
+        -------
+        list[dict]
+            OTG-shaped prefix dicts ready for serialisation into
+            ``BgpPrefixIpv4/6UnicastState``.
+        """
+        rows = self._get_learned_table(peer_obj, session_index, family)
+
+        if family == "v4":
+            prefixes = [
+                p for p in (self._row_to_ipv4_prefix(r) for r in rows)
+                if p is not None
+            ]
+            filters = (
+                bgp_prefix_request.ipv4_unicast_filters
+                if bgp_prefix_request is not None
+                else None
+            )
+            return self._apply_v4_filters(prefixes, filters)
+        else:
+            prefixes = [
+                p for p in (self._row_to_ipv6_prefix(r) for r in rows)
+                if p is not None
+            ]
+            filters = (
+                bgp_prefix_request.ipv6_unicast_filters
+                if bgp_prefix_request is not None
+                else None
+            )
+            return self._apply_v6_filters(prefixes, filters)
 
     def _configure_route(self, route, ixn_route):
         self._ngpf.set_ixn_routes(route, ixn_route)

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -1,5 +1,4 @@
 import re
-import time
 
 from snappi_ixnetwork.device.base import Base
 from snappi_ixnetwork.logger import get_ixnet_logger
@@ -103,7 +102,7 @@ class Bgp(Base):
         "as_confed_set": "assetconfederation",
     }
 
-    # OTG learned_information_filter → IxNetwork filterIpV*/filterIpV* Multivalue.
+    # OTG learned_information_filter.
     # Enabling a filter instructs IxNetwork to capture that route family in
     # learnedInfo.  Without at least one filter set to True the server stores
     # nothing and GetIPv4/6LearnedInfo returns empty results.
@@ -112,9 +111,6 @@ class Bgp(Base):
         "unicast_ipv6_prefix": "filterIpV6Unicast",
     }
 
-    # ------------------------------------------------------------------
-    # Address families for StatesRequest.bgp_prefixes
-    # ------------------------------------------------------------------
     # Every value of the OTG ``prefix_filters`` enum, mapped to the
     # ``BgpPrefixesState`` field it populates.
     _PREFIX_FILTER_FIELDS = {
@@ -159,15 +155,7 @@ class Bgp(Base):
     }
 
     # learnedInfo table ``Type`` -> address family, matched case-insensitively
-    # **by prefix**: the Type carries a trailing ordinal ('IPv4 Prefixes 1')
-    # which is assigned per fetch and is not stable between reads, so it must
-    # never be compared for equality.  An MPLS table is a distinct Type and
-    # therefore does not match either entry -- which is what keeps MPLS rows
-    # from being reported as plain unicast prefixes.
-    #
-    # These strings double as the server-side ``Table.find(Type=...)`` regex
-    # (see _table_type_pattern), so keep them free of regex metacharacters:
-    # they are matched literally, only anchored and alternated.
+
     _LEARNED_TABLE_FAMILIES = (
         ("IPv4 Prefixes", "ipv4_unicast"),
         ("IPv6 Prefixes", "ipv6_unicast"),
@@ -388,12 +376,8 @@ class Bgp(Base):
     # Learned-info helpers (used by ngpf.get_bgp_prefix_states)
     # ------------------------------------------------------------------
 
-    # IxNetwork single-char origin → OTG origin string
+    # IxNetwork origin → OTG origin string
     _IXN_ORIGIN_MAP = {
-        "i": "igp",
-        "e": "egp",
-        "?": "incomplete",
-        # accept long-form in case a future IxN version emits them
         "igp": "igp",
         "egp": "egp",
         "incomplete": "incomplete",
@@ -404,36 +388,18 @@ class Bgp(Base):
     # ------------------------------------------------------------------
     # The keys below are IxNetwork column *display names*.  RestPy exposes
     # no `name` attribute for learned-info columns: in ixnetwork_restpy
-    # 1.10.0 the `learnedInfo/table` resource's _SDM_ATT_MAP is only
+    # the `learnedInfo/table` resource's _SDM_ATT_MAP is only
     # {Actions, Columns, RowCount, Type, Values}, `learnedInfo` itself adds
     # only Id__/State, and the deprecated `col` child carries just `value`.
     # `columns` holds the display names, so keying off the display name is
     # the only option the API offers.
-    # Notes :
-    #   * 'IPv4 Prefix ' carries a trailing space.  _get_learned_table()
-    #     strips every column name, so the constants here are unpadded.
-    #   * an absent value arrives as 'NA', 'removePacket[ ]' or
-    #     'removePacket[N/A]' -- never a bare 'N/A'.  All are normalised to
-    #     None by _get_cell; 'removePacket' is matched by prefix because
-    #     the bracketed part varies (_NA_VALUE_PREFIXES).
-    #   * 'AIGP', 'Color', 'Large Community', 'SRv6 SID' and the locator
-    #     columns have no OTG counterpart and are deliberately unmapped.
-    #   * 'IPv6 Next Hop 2' is a second next-hop, not an alias of
-    #     'IPv6 Next Hop'; OTG has no field for it.
-    #   * this table has no extended-community column.
-    # A tuple with more than one entry is an ordered candidate list
-    # (first hit wins).  Keep these tuples minimal: every extra entry is
-    # a guess that hides a schema change instead of surfacing it.
-    #
-    # The IPv6 unicast table has not been captured yet -- entries tagged
-    # UNCONFIRMED are inferred from the IPv4 naming pattern above.
     _V4_ADDR_COLS = ("IPv4 Prefix",)
     _V6_ADDR_COLS = ("IPv6 Prefix",)
     _NLRI_COLS = ("Prefix Length",)
     _V4_NH_COLS = ("IPv4 Next Hop",)
     _V6_NH_COLS = ("IPv6 Next Hop",)
     # Legacy single next-hop column, used only as a fallback when neither
-    # explicit per-family column is present.  Not seen in 10.80.
+    # explicit per-family column is present.
     _NH_COLS = ("Next Hop",)
     _ORIGIN_COLS = ("Origin",)
     _LOCPREF_COLS = ("Local Preference",)
@@ -452,23 +418,6 @@ class Bgp(Base):
         """Return a list of ``(peer_name, restpy_peer_obj, session_index,
         family)`` for every BGP peer that matches *peer_names*.
 
-        Parameters
-        ----------
-        peer_names : list[str]
-            Snappi peer names to query.  An empty list means *all* configured
-            BGP peers.
-
-        Returns
-        -------
-        list of (str, restpy_obj, int, str)
-            *session_index* is 1-based (as required by
-            ``GetIPv4/6LearnedInfo``).  *family* is ``"v4"`` or ``"v6"``.
-
-        Raises
-        ------
-        Exception
-            If any name in *peer_names* is not found in the live topology.
-
         Limitations
         -----------
         Peers are found by walking the live NGPF tree rather than by looking
@@ -478,7 +427,7 @@ class Bgp(Base):
 
         * **Cost grows with the topology.** The walk runs on every call and
           nothing is cached between calls (the topology may have changed),
-          so a configuration with very many device groups pays for a full
+          so a configuration with many device groups pays for a full
           traversal each time.
         * **Only top-level device groups are searched.**
           ``DeviceGroup.find()`` returns the groups directly beneath the
@@ -569,9 +518,6 @@ class Bgp(Base):
 
     def _table_family(self, table_type):
         """Map a learnedInfo table ``Type`` to an OTG family, or ``None``.
-
-        Matched by prefix -- see :attr:`_LEARNED_TABLE_FAMILIES` for why the
-        trailing ordinal in ``'IPv4 Prefixes 1'`` must not be compared.
         """
         lowered = (table_type or "").strip().lower()
         for prefix, family in self._LEARNED_TABLE_FAMILIES:
@@ -585,13 +531,6 @@ class Bgp(Base):
         ``find()``'s named parameters are evaluated as regular expressions on
         the API server, so the requested families can be selected there
         rather than fetching every table and discarding most of them.
-
-        Verified against IxNetwork 10.80: anchoring, alternation and the
-        ``(?i)`` inline flag all work, and a pattern that matches nothing
-        returns an empty result rather than raising.  The flag matters --
-        without it the server match would be case-sensitive while
-        :meth:`_table_family` is not, so the two would disagree on a table
-        type that differed only in casing.
         """
         prefixes = [
             prefix
@@ -604,18 +543,6 @@ class Bgp(Base):
 
     def _find_learned_tables(self, learned_info, families):
         """Return ``(tables, fell_back)`` for one learnedInfo object.
-
-        The read is narrowed server-side to *families*.  When that returns
-        nothing the tables are re-read unfiltered, because an empty filtered
-        result is indistinguishable from "this peer learned no routes" -- and
-        without the re-read a table whose Type we no longer recognise would
-        produce no prefixes *and* no diagnostic.
-
-        Whether falling back indicates a problem depends on what the rows
-        turn out to be, which only the caller can see: a peer that simply
-        does not carry a requested family is the normal case and must stay
-        quiet.  So this reports the fallback and leaves the judgement to
-        :meth:`_get_learned_table`.
         """
         pattern = self._table_type_pattern(families)
         if pattern is None:
@@ -638,31 +565,7 @@ class Bgp(Base):
         """Trigger a learned-info fetch and return its rows **by family**.
 
         ``GetAllLearnedInfo`` (not ``GetIPv4/6LearnedInfo``) is the operation
-        that populates the ``Table`` child resource.  ``GetIPv4/6LearnedInfo``
-        only updates the deprecated inline ``Columns``/``Values`` fields which
-        are no longer written in IxNetwork 10.x.
-
-        A peer can carry tables for more than one family -- an MP-BGP session
-        over IPv4 may learn IPv6 NLRI -- so rows are grouped by the family
-        named in ``table.Type`` rather than by the peer's own IP version.
-        Tables whose Type is not a recognised family (EVPN, flow spec, MPLS,
-        ...) are skipped rather than merged, which is what stops their rows
-        being reported as plain unicast prefixes.
-
-        Parameters
-        ----------
-        peer_obj :
-            Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
-        families : list[str] or None
-            Families to fetch.  Used to narrow the read server-side; ``None``
-            reads every table.  Rows are still classified by table Type, so
-            passing this is an optimisation, not a correctness requirement.
-
-        Returns
-        -------
-        dict[str, list[dict[str, str]]]
-            ``{family: [{column_display_name: value_str}, ...]}``, keyed by
-            the OTG ``prefix_filters`` family name.
+        that populates the ``Table`` child resource. 
         """
         # --- Step 1: trigger the learned-info fetch -----------------------
         # Equivalent to right-click → "Get Learned Info" in the GUI.
@@ -750,13 +653,6 @@ class Bgp(Base):
                 )
             )
         elif fell_back and tables:
-            # The server-side Type filter missed a table that this code then
-            # understood perfectly well.  Not expected -- the filter is built
-            # from the same prefixes, case-insensitively -- so it means the
-            # server's regex handling differs from what was verified.  Harmless
-            # here (the rows were recovered) but worth knowing about, since it
-            # is the mechanism by which a future version could start losing
-            # prefixes silently.
             self.logger.warning(
                 "Learned-info Type filter did not match the %s table(s) for "
                 "peer %r, which were read and parsed anyway. Server-side "
@@ -769,11 +665,6 @@ class Bgp(Base):
 
     def _is_na(self, value):
         """Return True if *value* is an IxNetwork "no value" placeholder.
-
-        IxNetwork does not leave absent cells empty; it emits ``NA`` or
-        ``removePacket[ ]`` (the bracketed part varies).  Treating those as
-        data yields nonsense such as ``path_id=0`` from ``'NA'`` or an
-        ``ipv6_next_hop`` of ``'removePacket[ ]'``.
         """
         lowered = value.lower()
         if lowered in self._NA_VALUES:
@@ -786,8 +677,7 @@ class Bgp(Base):
         Candidate names are IxNetwork column *display names* -- RestPy
         exposes no ``name`` attribute for learned-info columns, so the
         display name is the only key available (see the note above the
-        ``_*_COLS`` constants).  Names are matched against the already
-        stripped keys built by :meth:`_get_learned_table`.
+        ``_*_COLS`` constants).
 
         Returns ``None`` when no candidate column is present, and also
         when the matched cell holds a "no value" placeholder such as
@@ -796,12 +686,7 @@ class Bgp(Base):
         Keyword Arguments
         -----------------
         warn : bool, default True
-            Log a warning when none of *col_names* is present in *row*, so
-            that a renamed or removed column surfaces in the log instead of
-            silently producing an incomplete prefix.  Pass ``warn=False``
-            for probes that legitimately expect a miss -- the address
-            columns are used to decide whether a row belongs to this
-            address family at all.
+            Log a warning when none of *col_names* is present in *row*.
         """
         warn = kwargs.pop("warn", True)
         if kwargs:
@@ -820,10 +705,6 @@ class Bgp(Base):
 
     def _warn_missing_column(self, col_names, row):
         """Warn once per candidate-column set that no candidate matched.
-
-        Deduplicated for the lifetime of one
-        :meth:`get_learned_prefixes` call so that a missing column costs
-        one log line rather than one per learned prefix.
         """
         if col_names in self._warned_columns:
             return
@@ -845,10 +726,6 @@ class Bgp(Base):
 
     # --- AS-path / community parsers ---------------------------------
 
-    # AS numbers are uint32 in OTG (``as_numbers`` itemformat).  Community
-    # ``as_number``/``as_custom`` are each capped at 65535 by the OTG
-    # model, and snappi raises at serialisation time for anything larger,
-    # so an out-of-range parse would fail the whole get_states call.
     _MAX_ASN = 2 ** 32 - 1
     _MAX_COMMUNITY_FIELD = 65535
 
@@ -903,12 +780,6 @@ class Bgp(Base):
         """Warn about an AS-path token that is not an asplain AS number."""
         hint = ""
         if self._ASDOT_RE.match(token):
-            # Deliberate non-support: IxNetwork 10.80 emits asplain
-            # ('<100 200>') and neither bgpIpv4Peer nor anything else in
-            # ixnetwork_restpy 1.10.0 exposes an asdot notation setting.
-            # Guessing at a format we have never observed is what made the
-            # learned-info column aliases wrong; if this warning ever
-            # fires, implement the conversion (X.Y = X * 65536 + Y) here.
             hint = (
                 " This looks like asdot notation; asdot is not parsed "
                 "because IxNetwork has only ever been observed emitting "
@@ -990,13 +861,13 @@ class Bgp(Base):
         if not cell or cell.strip().lower() in ("", "n/a"):
             return []
 
-        # IxNetwork emits spaces around the colon: the 10.80 capture shows
+        # IxNetwork emits spaces around the colon: the capture shows
         # '1 : 2'.  Normalise to '1:2' before tokenising, so that a spaced
         # pair does not split into three tokens.
         cell = re.sub(r"\s*:\s*", ":", cell)
 
         result = []
-        # Entries are separated by commas, whitespace, or both -- 10.80
+        # Entries are separated by commas, whitespace, or both --
         # emits '1 : 2, NO_EXPORT, 65535 : 65535'.
         for token in self._ASN_SEPARATOR_RE.split(cell.strip()):
             if not token:
@@ -1106,7 +977,6 @@ class Bgp(Base):
 
         nlri_cell = self._get_cell(row, *self._NLRI_COLS)
 
-        # Some IxN versions emit a full CIDR in the address column.
         if "/" in addr_cell:
             parts = addr_cell.split("/", 1)
             ipv4_address = parts[0]
@@ -1156,7 +1026,6 @@ class Bgp(Base):
 
         Returns ``None`` when the row lacks address information.
         """
-        # warn=False: see the matching probe in _row_to_ipv4_prefix.
         addr_cell = self._get_cell(row, *self._V6_ADDR_COLS, warn=False)
 
         if not addr_cell:
@@ -1242,8 +1111,7 @@ class Bgp(Base):
         """Return prefixes that match at least one IPv4 unicast filter.
 
         An empty *filters* list (or ``None``) means no restriction: all
-        prefixes are returned.  Multiple filters are OR-ed; within each
-        filter, fields are AND-ed.
+        prefixes are returned. 
         """
         if not filters:
             return prefixes
@@ -1257,8 +1125,6 @@ class Bgp(Base):
 
     def _apply_v6_filters(self, prefixes, filters):
         """Return prefixes that match at least one IPv6 unicast filter.
-
-        Semantics identical to :meth:`_apply_v4_filters`.
         """
         if not filters:
             return prefixes
@@ -1279,26 +1145,6 @@ class Bgp(Base):
         ``prefix_filters`` selects **which address families** to report;
         ``ipv4_unicast_filters``/``ipv6_unicast_filters`` then narrow the
         prefixes *within* a family.  This resolves the first of the three.
-
-        Parameters
-        ----------
-        prefix_filters : list[str] or None
-            Values from the OTG enum: ``ipv4_unicast``, ``ipv6_unicast``,
-            ``ipv4_mpls_unicast``, ``ipv6_mpls_unicast``.  Empty or ``None``
-            means every family this backend supports.
-
-        Returns
-        -------
-        list[str]
-            Family names, in a stable order.
-
-        Raises
-        ------
-        Exception
-            If a family is unknown, or is a valid OTG family that this
-            backend cannot translate yet.  Failing loudly is deliberate:
-            returning an empty list would look like "the peer learned
-            nothing", which is indistinguishable from a working query.
         """
         if not prefix_filters:
             return list(self._SUPPORTED_PREFIX_FILTERS)
@@ -1342,25 +1188,6 @@ class Bgp(Base):
         from, **not** from the peer's own IP version, so an MP-BGP session
         over IPv4 that has learned IPv6 NLRI reports those under
         ``ipv6_unicast_prefixes``.
-
-        Parameters
-        ----------
-        peer_obj :
-            Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
-        bgp_prefix_request :
-            Snappi ``BgpPrefixStateRequest`` (``request.bgp_prefixes``).
-            May be ``None`` when called without filter context.
-        families : list[str] or None
-            Families to report, from :meth:`resolve_prefix_filters`.
-            ``None`` means every supported family.
-
-        Returns
-        -------
-        dict[str, list[dict]]
-            ``{BgpPrefixesState field name: [prefix dict, ...]}``, holding
-            only the families this peer actually has a table for.  A family
-            whose filters exclude everything is present with an empty list,
-            which distinguishes "nothing matched" from "not carried".
         """
         # Fresh warning scope: a missing column is reported once per call,
         # not once per prefix, and not suppressed forever after the first.

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -117,6 +117,8 @@ class Bgp(Base):
         self.logger = get_ixnet_logger(__name__)
         self._bgp_evpn = BgpEvpn(ngpf)
         self._router_id = None
+        # get_learned_prefixes call by _warn_missing_column's caller.
+        self._warned_columns = set()
 
     def config(self, device):
         self.logger.debug("Configuring BGP")
@@ -335,20 +337,55 @@ class Bgp(Base):
         "incomplete": "incomplete",
     }
 
-    # Column-name aliases tried in order (first hit wins).  IxNetwork has
-    # varied slightly across versions; this covers the known variants.
-    _V4_ADDR_COLS    = ("IPv4 Prefix",)
-    _V6_ADDR_COLS    = ("IPv6 Address", "IPv6 Prefix", "IP Address", "Network Address", "Network")
-    _NLRI_COLS       = ("Prefix Length",)
-    _NH_COLS         = ("Next Hop",    "NextHop",   "Next-Hop")
-    _V4_NH_COLS      = ("IPv4 Next Hop",)
-    _V6_NH_COLS      = ("Ipv6 Next Hop",)
-    _ORIGIN_COLS     = ("Origin",)
-    _LOCPREF_COLS    = ("Local Preference", "Local Pref", "LocalPref")
-    _MED_COLS        = ("MED",         "Multi Exit Discriminator")
-    _ASPATH_COLS     = ("AS Path",     "AS-Path",   "AsPath")
-    _COMMUNITY_COLS  = ("Community",   "Communities")
-    _PATHID_COLS     = ("Path ID",     "PathId",    "Add Path ID")
+    # ------------------------------------------------------------------
+    # Learned-info column names
+    # ------------------------------------------------------------------
+    # The keys below are IxNetwork column *display names*.  RestPy exposes
+    # no `name` attribute for learned-info columns: in ixnetwork_restpy
+    # 1.10.0 the `learnedInfo/table` resource's _SDM_ATT_MAP is only
+    # {Actions, Columns, RowCount, Type, Values}, `learnedInfo` itself adds
+    # only Id__/State, and the deprecated `col` child carries just `value`.
+    # `columns` holds the display names, so keying off the display name is
+    # the only option the API offers.
+    # Notes :
+    #   * 'IPv4 Prefix ' carries a trailing space.  _get_learned_table()
+    #     strips every column name, so the constants here are unpadded.
+    #   * an absent value arrives as 'NA' or 'removePacket[ ]' -- not
+    #     'N/A'.  Both are normalised to None by _get_cell (_NA_VALUES).
+    #   * 'AIGP', 'Color', 'Large Community', 'SRv6 SID' and the locator
+    #     columns have no OTG counterpart and are deliberately unmapped.
+    #   * 'IPv6 Next Hop 2' is a second next-hop, not an alias of
+    #     'IPv6 Next Hop'; OTG has no field for it.
+    #   * this table has no extended-community column.
+    #
+    # A tuple with more than one entry is an ordered candidate list
+    # (first hit wins).  Keep these tuples minimal: every extra entry is
+    # a guess that hides a schema change instead of surfacing it.
+    #
+    # The IPv6 unicast table has not been captured yet -- entries tagged
+    # UNCONFIRMED are inferred from the IPv4 naming pattern above.
+    _V4_ADDR_COLS = ("IPv4 Prefix",)
+    # UNCONFIRMED: 'IPv6 Prefix' by symmetry with 'IPv4 Prefix';
+    # 'IPv6 Address' retained as the previously assumed name.
+    _V6_ADDR_COLS = ("IPv6 Prefix", "IPv6 Address")
+    _NLRI_COLS = ("Prefix Length",)
+    _V4_NH_COLS = ("IPv4 Next Hop",)
+    _V6_NH_COLS = ("IPv6 Next Hop",)
+    # Legacy single next-hop column, used only as a fallback when neither
+    # explicit per-family column is present.  Not seen in 10.80.
+    _NH_COLS = ("Next Hop",)
+    _ORIGIN_COLS = ("Origin",)
+    _LOCPREF_COLS = ("Local Preference",)
+    _MED_COLS = ("MED",)
+    _ASPATH_COLS = ("AS Path",)
+    _COMMUNITY_COLS = ("Community",)
+    _PATHID_COLS = ("Path ID",)
+
+    # Cell values that mean "no value" rather than data.  Compared
+    # case-insensitively against the stripped cell; 'removePacket[...]'
+    # is matched by prefix because the bracketed part varies.
+    _NA_VALUES = frozenset(("", "na", "n/a", "null", "none"))
+    _NA_VALUE_PREFIXES = ("removepacket",)
 
     def get_bgp_peer_objects(self, peer_names):
         """Return a list of ``(peer_name, restpy_peer_obj, session_index,
@@ -452,7 +489,7 @@ class Bgp(Base):
         Returns
         -------
         list[dict[str, str]]
-            One ``{column_name: value_str}`` dict per prefix row.
+            One ``{column_display_name: value_str}`` dict per prefix row.
         """
         # --- Step 1: trigger the learned-info fetch -----------------------
         # Equivalent to right-click → "Get Learned Info" in the GUI.
@@ -473,12 +510,16 @@ class Bgp(Base):
                     columns = table.Columns
                     if not columns:
                         continue
-                    # self.logger.warning(
-                    #     "_get_learned_table: peer=%r Type=%r "
-                    #     "Columns=%r RowCount=%d"
-                    #     % (peer_obj.Name, table.Type,
-                    #        columns, len(table.Values or []))
-                    # )
+                    self.logger.debug(
+                        "_get_learned_table: peer=%r Type=%r Columns=%r "
+                        "RowCount=%d"
+                        % (
+                            peer_obj.Name,
+                            table.Type,
+                            columns,
+                            len(table.Values or []),
+                        )
+                    )
                     col_idx = {col.strip(): i for i, col in enumerate(columns)}
                     for row_vals in (table.Values or []):
                         rows.append({
@@ -495,15 +536,73 @@ class Bgp(Base):
 
     # --- static low-level helpers ------------------------------------
 
-    @staticmethod
-    def _get_cell(row, *col_names):
-        """Return the stripped value of the first matching column in *row*,
-        or ``None`` if none of the candidate column names are present."""
+    def _is_na(self, value):
+        """Return True if *value* is an IxNetwork "no value" placeholder.
+
+        IxNetwork does not leave absent cells empty; it emits ``NA`` or
+        ``removePacket[ ]`` (the bracketed part varies).  Treating those as
+        data yields nonsense such as ``path_id=0`` from ``'NA'`` or an
+        ``ipv6_next_hop`` of ``'removePacket[ ]'``.
+        """
+        lowered = value.lower()
+        if lowered in self._NA_VALUES:
+            return True
+        return lowered.startswith(self._NA_VALUE_PREFIXES)
+
+    def _get_cell(self, row, *col_names, **kwargs):
+        """Return the value of the first matching column in *row*.
+
+        Candidate names are IxNetwork column *display names* -- RestPy
+        exposes no ``name`` attribute for learned-info columns, so the
+        display name is the only key available (see the note above the
+        ``_*_COLS`` constants).  Names are matched against the already
+        stripped keys built by :meth:`_get_learned_table`.
+
+        Returns ``None`` when no candidate column is present, and also
+        when the matched cell holds a "no value" placeholder such as
+        ``NA`` or ``removePacket[ ]`` (see :meth:`_is_na`).
+
+        Keyword Arguments
+        -----------------
+        warn : bool, default True
+            Log a warning when none of *col_names* is present in *row*, so
+            that a renamed or removed column surfaces in the log instead of
+            silently producing an incomplete prefix.  Pass ``warn=False``
+            for probes that legitimately expect a miss -- the address
+            columns are used to decide whether a row belongs to this
+            address family at all.
+        """
+        warn = kwargs.pop("warn", True)
+        if kwargs:
+            raise TypeError(
+                "_get_cell got unexpected keyword arguments: %s"
+                % sorted(kwargs)
+            )
         for name in col_names:
             val = row.get(name)
             if val is not None:
-                return val.strip()
+                val = val.strip()
+                return None if self._is_na(val) else val
+        if warn:
+            self._warn_missing_column(col_names, row)
         return None
+
+    def _warn_missing_column(self, col_names, row):
+        """Warn once per candidate-column set that no candidate matched.
+
+        Deduplicated for the lifetime of one
+        :meth:`get_learned_prefixes` call so that a missing column costs
+        one log line rather than one per learned prefix.
+        """
+        if col_names in self._warned_columns:
+            return
+        self._warned_columns.add(col_names)
+        self.logger.warning(
+            "Learned-info column not found: tried %s. Available columns: "
+            "%s. The corresponding field will be omitted from the "
+            "returned prefixes -- the IxNetwork column display name may "
+            "have changed." % (list(col_names), sorted(row))
+        )
 
     @staticmethod
     def _safe_int(s, default=0):
@@ -627,17 +726,57 @@ class Bgp(Base):
 
     # --- row → OTG prefix dict ---------------------------------------
 
+    def _get_next_hops(self, row):
+        """Return ``(ipv4_next_hop, ipv6_next_hop)`` for *row*.
+        """
+        ipv4_nh = self._get_cell(row, *self._V4_NH_COLS, warn=False)
+        ipv6_nh = self._get_cell(row, *self._V6_NH_COLS, warn=False)
+        if ipv4_nh is not None or ipv6_nh is not None:
+            return ipv4_nh, ipv6_nh
+
+        # Distinguish "column absent" from "column present but holding a
+        # placeholder" -- only the former is a schema change worth a
+        # warning.  A row legitimately carries no next hop for the family
+        # that does not apply to it.
+        explicit_cols = self._V4_NH_COLS + self._V6_NH_COLS
+        if self._has_any_column(row, explicit_cols):
+            return None, None
+
+        nh_cell = self._get_cell(row, *self._NH_COLS, warn=False)
+        if nh_cell is not None:
+            if ":" in nh_cell:
+                return None, nh_cell
+            return nh_cell, None
+
+        if not self._has_any_column(row, self._NH_COLS):
+            # No next-hop column of any kind: report the whole candidate
+            # set in one warning rather than one per candidate.
+            self._warn_missing_column(explicit_cols + self._NH_COLS, row)
+        return None, None
+
+    @staticmethod
+    def _has_any_column(row, col_names):
+        """Return True if *row* has any of *col_names* as a key.
+
+        Presence is independent of the cell's value: a column holding a
+        placeholder such as ``NA`` is still present.
+        """
+        return any(name in row for name in col_names)
+
     def _row_to_ipv4_prefix(self, row):
         """Convert a raw IxNetwork row dict to an OTG IPv4 unicast prefix dict.
 
         Returns ``None`` when the row lacks address information (e.g. it
         belongs to a different table type such as IPv4 MPLS).
         """
-        addr_cell = self._get_cell(row, *self._V4_ADDR_COLS)
-        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
+        # warn=False: a miss here means the row belongs to another address
+        # family, which is expected, not a schema change.
+        addr_cell = self._get_cell(row, *self._V4_ADDR_COLS, warn=False)
 
         if not addr_cell:
             return None
+
+        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
 
         # Some IxN versions emit a full CIDR in the address column.
         if "/" in addr_cell:
@@ -648,13 +787,7 @@ class Bgp(Base):
             ipv4_address = addr_cell
             prefix_length = self._safe_int(nlri_cell)
 
-        ipv4_nh = self._get_cell(row, *self._V4_NH_COLS) or None
-        ipv6_nh = self._get_cell(row, *self._V6_NH_COLS) or None
-        # Fall back to legacy single next-hop column, using ":" to distinguish.
-        if ipv4_nh is None and ipv6_nh is None:
-            nh_cell = self._get_cell(row, *self._NH_COLS) or ""
-            ipv4_nh = nh_cell if nh_cell and ":" not in nh_cell else None
-            ipv6_nh = nh_cell if ":" in nh_cell else None
+        ipv4_nh, ipv6_nh = self._get_next_hops(row)
 
         origin_raw = self._get_cell(row, *self._ORIGIN_COLS) or ""
         origin = self._IXN_ORIGIN_MAP.get(origin_raw.lower())
@@ -695,34 +828,34 @@ class Bgp(Base):
 
         Returns ``None`` when the row lacks address information.
         """
-        addr_cell = self._get_cell(row, *self._V6_ADDR_COLS)
-        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
+        # warn=False: see the matching probe in _row_to_ipv4_prefix.
+        addr_cell = self._get_cell(row, *self._V6_ADDR_COLS, warn=False)
 
         if not addr_cell:
             return None
 
+        nlri_cell = self._get_cell(row, *self._NLRI_COLS)
+
         if "/" in addr_cell:
             parts = addr_cell.split("/", 1)
-            ipv6_address  = parts[0]
+            ipv6_address = parts[0]
             prefix_length = self._safe_int(parts[1])
         else:
-            ipv6_address  = addr_cell
+            ipv6_address = addr_cell
             prefix_length = self._safe_int(nlri_cell)
 
-        nh_cell = self._get_cell(row, *self._NH_COLS) or ""
-        ipv6_nh = nh_cell if ":" in nh_cell else None
-        ipv4_nh = nh_cell if ":" not in nh_cell and nh_cell else None
+        ipv4_nh, ipv6_nh = self._get_next_hops(row)
 
         origin_raw = self._get_cell(row, *self._ORIGIN_COLS) or ""
         origin = self._IXN_ORIGIN_MAP.get(origin_raw.lower())
 
         prefix = {
-            "ipv6_address"  : ipv6_address,
-            "prefix_length" : prefix_length,
-            "as_path"       : self._parse_as_path(
+            "ipv6_address": ipv6_address,
+            "prefix_length": prefix_length,
+            "as_path": self._parse_as_path(
                 self._get_cell(row, *self._ASPATH_COLS)
             ),
-            "communities"   : self._parse_communities(
+            "communities": self._parse_communities(
                 self._get_cell(row, *self._COMMUNITY_COLS)
             ),
         }
@@ -837,6 +970,10 @@ class Bgp(Base):
             OTG-shaped prefix dicts ready for serialisation into
             ``BgpPrefixIpv4/6UnicastState``.
         """
+        # Fresh warning scope: a missing column is reported once per call,
+        # not once per prefix, and not suppressed forever after the first.
+        self._warned_columns = set()
+
         rows = self._get_learned_table(peer_obj, session_index, family)
 
         if family == "v4":

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 from snappi_ixnetwork.device.base import Base
@@ -350,14 +351,15 @@ class Bgp(Base):
     # Notes :
     #   * 'IPv4 Prefix ' carries a trailing space.  _get_learned_table()
     #     strips every column name, so the constants here are unpadded.
-    #   * an absent value arrives as 'NA' or 'removePacket[ ]' -- not
-    #     'N/A'.  Both are normalised to None by _get_cell (_NA_VALUES).
+    #   * an absent value arrives as 'NA', 'removePacket[ ]' or
+    #     'removePacket[N/A]' -- never a bare 'N/A'.  All are normalised to
+    #     None by _get_cell; 'removePacket' is matched by prefix because
+    #     the bracketed part varies (_NA_VALUE_PREFIXES).
     #   * 'AIGP', 'Color', 'Large Community', 'SRv6 SID' and the locator
     #     columns have no OTG counterpart and are deliberately unmapped.
     #   * 'IPv6 Next Hop 2' is a second next-hop, not an alias of
     #     'IPv6 Next Hop'; OTG has no field for it.
     #   * this table has no extended-community column.
-    #
     # A tuple with more than one entry is an ordered candidate list
     # (first hit wins).  Keep these tuples minimal: every extra entry is
     # a guess that hides a schema change instead of surfacing it.
@@ -365,9 +367,7 @@ class Bgp(Base):
     # The IPv6 unicast table has not been captured yet -- entries tagged
     # UNCONFIRMED are inferred from the IPv4 naming pattern above.
     _V4_ADDR_COLS = ("IPv4 Prefix",)
-    # UNCONFIRMED: 'IPv6 Prefix' by symmetry with 'IPv4 Prefix';
-    # 'IPv6 Address' retained as the previously assumed name.
-    _V6_ADDR_COLS = ("IPv6 Prefix", "IPv6 Address")
+    _V6_ADDR_COLS = ("IPv6 Prefix",)
     _NLRI_COLS = ("Prefix Length",)
     _V4_NH_COLS = ("IPv4 Next Hop",)
     _V6_NH_COLS = ("IPv6 Next Hop",)
@@ -614,6 +614,80 @@ class Bgp(Base):
 
     # --- AS-path / community parsers ---------------------------------
 
+    # AS numbers are uint32 in OTG (``as_numbers`` itemformat).  Community
+    # ``as_number``/``as_custom`` are each capped at 65535 by the OTG
+    # model, and snappi raises at serialisation time for anything larger,
+    # so an out-of-range parse would fail the whole get_states call.
+    _MAX_ASN = 2 ** 32 - 1
+    _MAX_COMMUNITY_FIELD = 65535
+
+    _ASDOT_RE = re.compile(r"^\d+\.\d+$")
+
+    # Members within an AS-path group are separated by whitespace, commas
+    # or both: 10.80 emits AS_SEQ as '<100 200>' but AS_SET as '{300,400}'.
+    # The same splitter is reused for the comma-separated community list.
+    _ASN_SEPARATOR_RE = re.compile(r"[,\s]+")
+
+    # Well-known community names → OTG type.  Keys are the *normalised*
+    # form: lower-cased with '-' folded to '_', because IxNetwork has been
+    # observed emitting both 'no-export' and the uppercase 'NO_EXPORT'.
+    _WELL_KNOWN_COMMUNITIES = {
+        "no_export": "no_export",
+        "noexport": "no_export",
+        "no_advertise": "no_advertised",
+        "noadvertise": "no_advertised",
+        "no_advertised": "no_advertised",
+        "no_export_subconfed": "no_export_subconfed",
+        "noexport_subconfed": "no_export_subconfed",
+        "llgr_stale": "llgr_stale",
+        "no_llgr": "no_llgr",
+    }
+
+    def _parse_asn_list(self, text):
+        """Parse comma- and/or whitespace-separated AS numbers from *text*.
+
+        Anything that is not a plain (asplain) uint32 is skipped **with a
+        warning** rather than dropped silently -- a silent drop turns a
+        format surprise into a wrong AS path, which is exactly the kind of
+        result these states are used to assert on.
+        """
+        asns = []
+        for token in self._ASN_SEPARATOR_RE.split(text.strip()):
+            if not token:
+                continue
+            if token.isdigit():
+                value = int(token)
+                if value <= self._MAX_ASN:
+                    asns.append(value)
+                    continue
+                self.logger.warning(
+                    "Skipping AS number %s in learned AS path: exceeds the "
+                    "uint32 maximum (%d)." % (token, self._MAX_ASN)
+                )
+                continue
+            self._warn_bad_asn(token)
+        return asns
+
+    def _warn_bad_asn(self, token):
+        """Warn about an AS-path token that is not an asplain AS number."""
+        hint = ""
+        if self._ASDOT_RE.match(token):
+            # Deliberate non-support: IxNetwork 10.80 emits asplain
+            # ('<100 200>') and neither bgpIpv4Peer nor anything else in
+            # ixnetwork_restpy 1.10.0 exposes an asdot notation setting.
+            # Guessing at a format we have never observed is what made the
+            # learned-info column aliases wrong; if this warning ever
+            # fires, implement the conversion (X.Y = X * 65536 + Y) here.
+            hint = (
+                " This looks like asdot notation; asdot is not parsed "
+                "because IxNetwork has only ever been observed emitting "
+                "asplain. Convert as X.Y = X * 65536 + Y if needed."
+            )
+        self.logger.warning(
+            "Skipping unparseable AS number %r in learned AS path.%s"
+            % (token, hint)
+        )
+
     def _parse_as_path(self, cell):
         """Convert an IxNetwork AS-path string to an OTG ``as_path`` dict.
 
@@ -653,7 +727,7 @@ class Bgp(Base):
                 _flush_seq()
                 end = token.find(close, i + 1)
                 inner = token[i + 1 : end if end != -1 else len(token)]
-                asns = [int(x) for x in inner.split() if x.isdigit()]
+                asns = self._parse_asn_list(inner)
                 segments.append({"type": seg_type, "as_numbers": asns})
                 i = (end + 1) if end != -1 else len(token)
             else:
@@ -663,9 +737,7 @@ class Bgp(Base):
                     pos = token.find(delim, i)
                     if pos != -1 and pos < next_group:
                         next_group = pos
-                for part in token[i:next_group].split():
-                    if part.isdigit():
-                        seq_buf.append(int(part))
+                seq_buf.extend(self._parse_asn_list(token[i:next_group]))
                 i = next_group
 
         _flush_seq()
@@ -674,8 +746,11 @@ class Bgp(Base):
     def _parse_communities(self, cell):
         """Convert an IxNetwork communities string to a list of OTG dicts.
 
-        Handled formats::
+        Handled formats (the first is what 10.80 actually emits)::
 
+            "1 : 2, NO_EXPORT, 65535 : 65535"
+                           → two ``manual_as_number`` entries plus
+                             ``no_export``
             "1:2 3:4"      → two ``manual_as_number`` entries
             "no-export"    → ``no_export`` well-known entry
             "no-advertise" → ``no_advertised`` well-known entry
@@ -684,43 +759,65 @@ class Bgp(Base):
         if not cell or cell.strip().lower() in ("", "n/a"):
             return []
 
-        # IxNetwork sometimes emits spaces around the colon, e.g. "1 : 2".
-        # Normalise to "1:2" before tokenising.
-        import re
-        cell = re.sub(r'\s*:\s*', ':', cell)
-
-        _WELL_KNOWN = {
-            "no-export": "no_export",
-            "noexport": "no_export",
-            "no-advertise": "no_advertised",
-            "noadvertise": "no_advertised",
-            "no-advertised": "no_advertised",
-            "no_export_subconfed": "no_export_subconfed",
-            "no-export-subconfed": "no_export_subconfed",
-            "llgr_stale": "llgr_stale",
-            "no_llgr": "no_llgr",
-        }
+        # IxNetwork emits spaces around the colon: the 10.80 capture shows
+        # '1 : 2'.  Normalise to '1:2' before tokenising, so that a spaced
+        # pair does not split into three tokens.
+        cell = re.sub(r"\s*:\s*", ":", cell)
 
         result = []
-        for token in cell.split():
-            lower = token.lower()
-            if lower in _WELL_KNOWN:
-                result.append({"type": _WELL_KNOWN[lower]})
+        # Entries are separated by commas, whitespace, or both -- 10.80
+        # emits '1 : 2, NO_EXPORT, 65535 : 65535'.
+        for token in self._ASN_SEPARATOR_RE.split(cell.strip()):
+            if not token:
+                continue
+            # Well-known names arrive in several spellings across versions
+            # and columns: 'no-export' and the uppercase 'NO_EXPORT' have
+            # both been observed, so normalise separators before lookup.
+            well_known = self._WELL_KNOWN_COMMUNITIES.get(
+                token.lower().replace("-", "_")
+            )
+            if well_known is not None:
+                result.append({"type": well_known})
             elif ":" in token:
                 parts = token.split(":", 1)
                 try:
-                    result.append({
-                        "type": "manual_as_number",
-                        "as_number": int(parts[0]),
-                        "as_custom": int(parts[1]),
-                    })
+                    as_number = int(parts[0])
+                    as_custom = int(parts[1])
                 except (ValueError, IndexError):
+                    # e.g. a large community 'X:Y:Z' -- int('Y:Z') raises.
                     self.logger.warning(
-                        "1. Skipping unrecognised community token: %s" % token
+                        "Skipping unrecognised community token %r: not an "
+                        "<as_number>:<as_custom> pair." % token
                     )
+                    continue
+                over = [
+                    name
+                    for name, value in (
+                        ("as_number", as_number),
+                        ("as_custom", as_custom),
+                    )
+                    if value > self._MAX_COMMUNITY_FIELD
+                ]
+                if over:
+                    # Emitting this would raise at snappi serialisation
+                    # time and fail the whole get_states call, so skip it.
+                    self.logger.warning(
+                        "Skipping community token %r: %s exceeds the OTG "
+                        "maximum of %d."
+                        % (token, " and ".join(over),
+                           self._MAX_COMMUNITY_FIELD)
+                    )
+                    continue
+                result.append({
+                    "type": "manual_as_number",
+                    "as_number": as_number,
+                    "as_custom": as_custom,
+                })
             else:
                 self.logger.warning(
-                    "2. Skipping unrecognised community token: %s" % token
+                    "Skipping unrecognised community token %r: not a "
+                    "well-known name or an <as_number>:<as_custom> pair."
+                    % token
                 )
         return result
 

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -435,12 +435,6 @@ class Bgp(Base):
     def _get_learned_table(self, peer_obj, session_index, family):
         """Trigger learned-info fetch and return rows as column-keyed dicts.
 
-        Implements the RestPy pattern from the official IxNetwork sample
-        ``samples/protocols/bgp_learned_info.py``::
-
-            bgp.GetAllLearnedInfo()
-            learned_info_table = bgp.LearnedInfo.find().Table.find()
-
         ``GetAllLearnedInfo`` (not ``GetIPv4/6LearnedInfo``) is the operation
         that populates the ``Table`` child resource.  ``GetIPv4/6LearnedInfo``
         only updates the deprecated inline ``Columns``/``Values`` fields which

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -112,6 +112,48 @@ class Bgp(Base):
         "unicast_ipv6_prefix": "filterIpV6Unicast",
     }
 
+    # ------------------------------------------------------------------
+    # Address families for StatesRequest.bgp_prefixes
+    # ------------------------------------------------------------------
+    # Every value of the OTG ``prefix_filters`` enum, mapped to the
+    # ``BgpPrefixesState`` field it populates.
+    _PREFIX_FILTER_FIELDS = {
+        "ipv4_unicast": "ipv4_unicast_prefixes",
+        "ipv6_unicast": "ipv6_unicast_prefixes",
+        "ipv4_mpls_unicast": "ipv4_mpls_unicast_prefixes",
+        "ipv6_mpls_unicast": "ipv6_mpls_unicast_prefixes",
+    }
+
+    # The subset this backend can translate today.  An empty prefix_filters
+    # means "all supported families", so this is also the default.
+    _SUPPORTED_PREFIX_FILTERS = ("ipv4_unicast", "ipv6_unicast")
+
+    # How to turn a row of each family into an OTG prefix, and which
+    # per-family filter list applies to it.
+    _FAMILY_TRANSLATION = {
+        "ipv4_unicast": (
+            "_row_to_ipv4_prefix",
+            "_apply_v4_filters",
+            "ipv4_unicast_filters",
+        ),
+        "ipv6_unicast": (
+            "_row_to_ipv6_prefix",
+            "_apply_v6_filters",
+            "ipv6_unicast_filters",
+        ),
+    }
+
+    # learnedInfo table ``Type`` -> address family, matched case-insensitively
+    # **by prefix**: the Type carries a trailing ordinal ('IPv4 Prefixes 1')
+    # which is assigned per fetch and is not stable between reads, so it must
+    # never be compared for equality.  An MPLS table is a distinct Type and
+    # therefore does not match either entry -- which is what keeps MPLS rows
+    # from being reported as plain unicast prefixes.
+    _LEARNED_TABLE_FAMILIES = (
+        ("ipv4 prefixes", "ipv4_unicast"),
+        ("ipv6 prefixes", "ipv6_unicast"),
+    )
+
     def __init__(self, ngpf):
         super(Bgp, self).__init__()
         self._ngpf = ngpf
@@ -506,27 +548,43 @@ class Bgp(Base):
                 continue
             results.append((name, peer_obj, idx + 1, family))
 
-    def _get_learned_table(self, peer_obj, session_index, family):
-        """Trigger learned-info fetch and return rows as column-keyed dicts.
+    def _table_family(self, table_type):
+        """Map a learnedInfo table ``Type`` to an OTG family, or ``None``.
+
+        Matched by prefix -- see :attr:`_LEARNED_TABLE_FAMILIES` for why the
+        trailing ordinal in ``'IPv4 Prefixes 1'`` must not be compared.
+        """
+        lowered = (table_type or "").strip().lower()
+        for prefix, family in self._LEARNED_TABLE_FAMILIES:
+            if lowered.startswith(prefix):
+                return family
+        return None
+
+    def _get_learned_table(self, peer_obj):
+        """Trigger a learned-info fetch and return its rows **by family**.
 
         ``GetAllLearnedInfo`` (not ``GetIPv4/6LearnedInfo``) is the operation
         that populates the ``Table`` child resource.  ``GetIPv4/6LearnedInfo``
         only updates the deprecated inline ``Columns``/``Values`` fields which
         are no longer written in IxNetwork 10.x.
 
+        A peer can carry tables for more than one family -- an MP-BGP session
+        over IPv4 may learn IPv6 NLRI -- so rows are grouped by the family
+        named in ``table.Type`` rather than by the peer's own IP version.
+        Tables whose Type is not a recognised family (EVPN, flow spec, MPLS,
+        ...) are skipped rather than merged, which is what stops their rows
+        being reported as plain unicast prefixes.
+
         Parameters
         ----------
         peer_obj :
             Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
-        session_index : int
-            Informational; the trigger covers all sessions on *peer_obj*.
-        family : str
-            ``"v4"`` or ``"v6"``.
 
         Returns
         -------
-        list[dict[str, str]]
-            One ``{column_display_name: value_str}`` dict per prefix row.
+        dict[str, list[dict[str, str]]]
+            ``{family: [{column_display_name: value_str}, ...]}``, keyed by
+            the OTG ``prefix_filters`` family name.
         """
         # --- Step 1: trigger the learned-info fetch -----------------------
         # Equivalent to right-click → "Get Learned Info" in the GUI.
@@ -537,27 +595,32 @@ class Bgp(Base):
                 "GetAllLearnedInfo failed for peer %r: %s"
                 % (peer_obj.Name, e)
             )
-            return []
+            return {}
 
         # --- Step 2: read LearnedInfo.find().Table.find() -----------------
-        rows = []
+        tables = {}
         try:
             for li in peer_obj.LearnedInfo.find():
                 for table in li.Table.find():
                     columns = table.Columns
                     if not columns:
                         continue
+                    family = self._table_family(table.Type)
                     self.logger.debug(
-                        "_get_learned_table: peer=%r Type=%r Columns=%r "
-                        "RowCount=%d"
+                        "_get_learned_table: peer=%r Type=%r family=%r "
+                        "Columns=%r RowCount=%d"
                         % (
                             peer_obj.Name,
                             table.Type,
+                            family,
                             columns,
                             len(table.Values or []),
                         )
                     )
+                    if family is None:
+                        continue
                     col_idx = {col.strip(): i for i, col in enumerate(columns)}
+                    rows = tables.setdefault(family, [])
                     for row_vals in (table.Values or []):
                         rows.append({
                             col: row_vals[i]
@@ -569,7 +632,7 @@ class Bgp(Base):
                 "_get_learned_table: Table.find() failed for peer %r: %s"
                 % (peer_obj.Name, e)
             )
-        return rows
+        return tables
 
     # --- static low-level helpers ------------------------------------
 
@@ -1078,60 +1141,127 @@ class Bgp(Base):
 
     # --- public orchestrator -----------------------------------------
 
-    def get_learned_prefixes(self, peer_obj, session_index, family,
-                             bgp_prefix_request):
-        """Fetch and translate learned prefixes for one peer session.
+    def resolve_prefix_filters(self, prefix_filters):
+        """Return the address families a ``bgp_prefixes`` request asks for.
 
-        Calls :meth:`_get_learned_table` to retrieve raw IxNetwork rows,
-        converts each row to an OTG prefix dict, then applies any
-        unicast filters present in *bgp_prefix_request*.
+        ``StatesRequest.bgp_prefixes`` carries three independent filters.
+        ``prefix_filters`` selects **which address families** to report;
+        ``ipv4_unicast_filters``/``ipv6_unicast_filters`` then narrow the
+        prefixes *within* a family.  This resolves the first of the three.
+
+        Parameters
+        ----------
+        prefix_filters : list[str] or None
+            Values from the OTG enum: ``ipv4_unicast``, ``ipv6_unicast``,
+            ``ipv4_mpls_unicast``, ``ipv6_mpls_unicast``.  Empty or ``None``
+            means every family this backend supports.
+
+        Returns
+        -------
+        list[str]
+            Family names, in a stable order.
+
+        Raises
+        ------
+        Exception
+            If a family is unknown, or is a valid OTG family that this
+            backend cannot translate yet.  Failing loudly is deliberate:
+            returning an empty list would look like "the peer learned
+            nothing", which is indistinguishable from a working query.
+        """
+        if not prefix_filters:
+            return list(self._SUPPORTED_PREFIX_FILTERS)
+
+        requested = list(prefix_filters)
+
+        unknown = [
+            f for f in requested if f not in self._PREFIX_FILTER_FIELDS
+        ]
+        if unknown:
+            raise Exception(
+                "Unknown bgp_prefixes prefix_filters value(s): %s. Valid "
+                "values are %s."
+                % (sorted(unknown), sorted(self._PREFIX_FILTER_FIELDS))
+            )
+
+        unsupported = [
+            f for f in requested if f not in self._SUPPORTED_PREFIX_FILTERS
+        ]
+        if unsupported:
+            raise Exception(
+                "bgp_prefixes prefix_filters %s is not supported by the "
+                "IxNetwork backend yet; only %s can be retrieved."
+                % (sorted(unsupported), list(self._SUPPORTED_PREFIX_FILTERS))
+            )
+
+        # Deduplicate while keeping a deterministic order.
+        return [
+            f for f in self._SUPPORTED_PREFIX_FILTERS if f in set(requested)
+        ]
+
+    def get_learned_prefixes(self, peer_obj, bgp_prefix_request,
+                             families=None):
+        """Fetch and translate one peer's learned prefixes, by family.
+
+        Calls :meth:`_get_learned_table` for the raw rows, converts each row
+        to an OTG prefix dict, then applies the per-family unicast filters
+        from *bgp_prefix_request*.
+
+        The family of a prefix comes from the learned-info table it was read
+        from, **not** from the peer's own IP version, so an MP-BGP session
+        over IPv4 that has learned IPv6 NLRI reports those under
+        ``ipv6_unicast_prefixes``.
 
         Parameters
         ----------
         peer_obj :
             Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
-        session_index : int
-            1-based session index (from :meth:`get_bgp_peer_objects`).
-        family : str
-            ``"v4"`` or ``"v6"``.
         bgp_prefix_request :
             Snappi ``BgpPrefixStateRequest`` (``request.bgp_prefixes``).
             May be ``None`` when called without filter context.
+        families : list[str] or None
+            Families to report, from :meth:`resolve_prefix_filters`.
+            ``None`` means every supported family.
 
         Returns
         -------
-        list[dict]
-            OTG-shaped prefix dicts ready for serialisation into
-            ``BgpPrefixIpv4/6UnicastState``.
+        dict[str, list[dict]]
+            ``{BgpPrefixesState field name: [prefix dict, ...]}``, holding
+            only the families this peer actually has a table for.  A family
+            whose filters exclude everything is present with an empty list,
+            which distinguishes "nothing matched" from "not carried".
         """
         # Fresh warning scope: a missing column is reported once per call,
         # not once per prefix, and not suppressed forever after the first.
         self._warned_columns = set()
 
-        rows = self._get_learned_table(peer_obj, session_index, family)
+        if families is None:
+            families = self._SUPPORTED_PREFIX_FILTERS
 
-        if family == "v4":
+        tables = self._get_learned_table(peer_obj)
+
+        prefixes_by_field = {}
+        for family in families:
+            if family not in tables:
+                continue
+            row_method, filter_method, filters_attr = (
+                self._FAMILY_TRANSLATION[family]
+            )
+            to_prefix = getattr(self, row_method)
             prefixes = [
-                p for p in (self._row_to_ipv4_prefix(r) for r in rows)
+                p
+                for p in (to_prefix(row) for row in tables[family])
                 if p is not None
             ]
             filters = (
-                bgp_prefix_request.ipv4_unicast_filters
+                getattr(bgp_prefix_request, filters_attr, None)
                 if bgp_prefix_request is not None
                 else None
             )
-            return self._apply_v4_filters(prefixes, filters)
-        else:
-            prefixes = [
-                p for p in (self._row_to_ipv6_prefix(r) for r in rows)
-                if p is not None
-            ]
-            filters = (
-                bgp_prefix_request.ipv6_unicast_filters
-                if bgp_prefix_request is not None
-                else None
-            )
-            return self._apply_v6_filters(prefixes, filters)
+            prefixes_by_field[self._PREFIX_FILTER_FIELDS[family]] = getattr(
+                self, filter_method
+            )(prefixes, filters)
+        return prefixes_by_field
 
     def _configure_route(self, route, ixn_route):
         self._ngpf.set_ixn_routes(route, ixn_route)

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -1,3 +1,5 @@
+import time
+
 from snappi_ixnetwork.device.base import Base
 from snappi_ixnetwork.logger import get_ixnet_logger
 from snappi_ixnetwork.device.bgpevpn import BgpEvpn
@@ -98,6 +100,15 @@ class Bgp(Base):
         "as_set": "asset",
         "as_confed_seq": "asseqconfederation",
         "as_confed_set": "assetconfederation",
+    }
+
+    # OTG learned_information_filter → IxNetwork filterIpV*/filterIpV* Multivalue.
+    # Enabling a filter instructs IxNetwork to capture that route family in
+    # learnedInfo.  Without at least one filter set to True the server stores
+    # nothing and GetIPv4/6LearnedInfo returns empty results.
+    _LEARNED_INFO_FILTER = {
+        "unicast_ipv4_prefix": "filterIpV4Unicast",
+        "unicast_ipv6_prefix": "filterIpV6Unicast",
     }
 
     def __init__(self, ngpf):
@@ -214,6 +225,11 @@ class Bgp(Base):
                 )
             self._bgp_route_builder(bgp_peer, ixn_bgpv4)
             self._bgp_evpn.config(bgp_peer, ixn_bgpv4)
+            lif = bgp_peer.get("learned_information_filter")
+            if lif is not None:
+                self.configure_multivalues(
+                    lif, ixn_bgpv4, Bgp._LEARNED_INFO_FILTER
+                )
 
     def _config_bgpv6(self, bgp_peers, ixn_ipv6):
         self.logger.debug("Configuring BGPv6 Peer")
@@ -239,6 +255,11 @@ class Bgp(Base):
                 )
             self._bgp_route_builder(bgp_peer, ixn_bgpv6)
             self._bgp_evpn.config(bgp_peer, ixn_bgpv6)
+            lif = bgp_peer.get("learned_information_filter")
+            if lif is not None:
+                self.configure_multivalues(
+                    lif, ixn_bgpv6, Bgp._LEARNED_INFO_FILTER
+                )
 
     def _bgp_route_builder(self, bgp_peer, ixn_bgp):
         v4_routes = bgp_peer.get("v4_routes")
@@ -316,8 +337,8 @@ class Bgp(Base):
 
     # Column-name aliases tried in order (first hit wins).  IxNetwork has
     # varied slightly across versions; this covers the known variants.
-    _V4_ADDR_COLS    = ("IP Address",  "Network Address", "Network")
-    _V6_ADDR_COLS    = ("IPv6 Address", "IP Address", "Network Address", "Network")
+    _V4_ADDR_COLS    = ("IPv4 Prefix", "IP Address",  "Network Address", "Network", "Network Prefix")
+    _V6_ADDR_COLS    = ("IPv6 Address", "IPv6 Prefix", "IP Address", "Network Address", "Network")
     _NLRI_COLS       = ("NLRI", "Prefix Length", "Prefix")
     _NH_COLS         = ("Next Hop",    "NextHop",   "Next-Hop")
     _ORIGIN_COLS     = ("Origin",)
@@ -353,18 +374,20 @@ class Bgp(Base):
         results = []
 
         topologies = self._ngpf.api._ixnetwork.Topology.find()
-        bgpv4_peers = (
-            topologies.DeviceGroup.find()
-            .Ethernet.find()
-            .Ipv4.find()
-            .BgpIpv4Peer.find()
-        )
-        bgpv6_peers = (
-            topologies.DeviceGroup.find()
-            .Ethernet.find()
-            .Ipv6.find()
-            .BgpIpv6Peer.find()
-        )
+        dg_chain = topologies.DeviceGroup.find().Ethernet.find()
+
+        try:
+            bgpv4_peers = dg_chain.Ipv4.find().BgpIpv4Peer.find()
+        except Exception:
+            # No IPv4 interfaces in the current topology (e.g. IPv6-only test).
+            bgpv4_peers = []
+
+        try:
+            bgpv6_peers = dg_chain.Ipv6.find().BgpIpv6Peer.find()
+        except Exception:
+            # No IPv6 interfaces in the current topology (e.g. IPv4-only test).
+            bgpv6_peers = []
+
         for peer_obj in bgpv4_peers:
             self._collect_peer_entries(
                 peer_obj, "v4", requested, ixn_object_names, results
@@ -408,60 +431,75 @@ class Bgp(Base):
             results.append((name, peer_obj, idx + 1, family))
 
     def _get_learned_table(self, peer_obj, session_index, family):
-        """Refresh learned-info for *session_index* and return the rows.
+        """Trigger learned-info fetch and return rows as column-keyed dicts.
 
-        Calls ``GetIPv4LearnedInfo`` (or v6 equivalent) on the RestPy peer
-        object to request a data refresh from IxNetwork, then reads the
-        resulting ``LearnedInfo → Table`` hierarchy and converts each row
-        into a ``{column_name: value_str}`` dict.
+        Implements the RestPy pattern from the official IxNetwork sample
+        ``samples/protocols/bgp_learned_info.py``::
+
+            bgp.GetAllLearnedInfo()
+            learned_info_table = bgp.LearnedInfo.find().Table.find()
+
+        ``GetAllLearnedInfo`` (not ``GetIPv4/6LearnedInfo``) is the operation
+        that populates the ``Table`` child resource.  ``GetIPv4/6LearnedInfo``
+        only updates the deprecated inline ``Columns``/``Values`` fields which
+        are no longer written in IxNetwork 10.x.
 
         Parameters
         ----------
-        peer_obj : restpy bgpIpv4Peer or bgpIpv6Peer
-            Live RestPy peer object returned by
-            ``get_bgp_peer_objects``.
+        peer_obj :
+            Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
         session_index : int
-            1-based session index within *peer_obj*.
+            Informational; the trigger covers all sessions on *peer_obj*.
         family : str
-            ``"v4"`` for IPv4 unicast; ``"v6"`` for IPv6 unicast.
+            ``"v4"`` or ``"v6"``.
 
         Returns
         -------
         list[dict[str, str]]
-            One dict per prefix row; keys are the IxNetwork column headers.
-            Returns an empty list when the peer is not yet started or on
-            any error.
+            One ``{column_name: value_str}`` dict per prefix row.
         """
+        # --- Step 1: trigger the learned-info fetch -----------------------
+        # Equivalent to right-click → "Get Learned Info" in the GUI.
         try:
-            if family == "v4":
-                peer_obj.GetIPv4LearnedInfo(
-                    SessionIndices=[session_index]
-                )
-            else:
-                peer_obj.GetIPv6LearnedInfo(
-                    SessionIndices=[session_index]
-                )
+            peer_obj.GetAllLearnedInfo()
         except Exception as e:
             self.logger.warning(
-                "GetIPv%sLearnedInfo failed for session %d: %s"
-                % ("4" if family == "v4" else "6", session_index, e)
+                "GetAllLearnedInfo failed for peer %r: %s"
+                % (peer_obj.Name, e)
             )
             return []
 
+        # --- Step 2: read LearnedInfo.find().Table.find() -----------------
         rows = []
-        for li in peer_obj.LearnedInfo.find():
-            for table in li.Table.find():
-                columns = table.Columns
-                if not columns:
-                    continue
-                col_idx = {col: i for i, col in enumerate(columns)}
-                for row_vals in (table.Values or []):
-                    row = {
-                        col: row_vals[i]
-                        for col, i in col_idx.items()
-                        if i < len(row_vals)
-                    }
-                    rows.append(row)
+        try:
+            for li in peer_obj.LearnedInfo.find():
+                for table in li.Table.find():
+                    columns = table.Columns
+                    if not columns:
+                        continue
+                    self.logger.warning(
+                        "_get_learned_table: peer=%r Type=%r "
+                        "Columns=%r RowCount=%d"
+                        % (peer_obj.Name, table.Type,
+                           columns, len(table.Values or []))
+                    )
+                    col_idx = {col: i for i, col in enumerate(columns)}
+                    for row_vals in (table.Values or []):
+                        rows.append({
+                            col: row_vals[i]
+                            for col, i in col_idx.items()
+                            if i < len(row_vals)
+                        })
+        except Exception as e:
+            self.logger.warning(
+                "_get_learned_table: Table.find() failed for peer %r: %s"
+                % (peer_obj.Name, e)
+            )
+
+        self.logger.warning(
+            "_get_learned_table: peer=%r family=%s total_rows=%d"
+            % (peer_obj.Name, family, len(rows))
+        )
         return rows
 
     # --- static low-level helpers ------------------------------------
@@ -810,6 +848,8 @@ class Bgp(Base):
                 if bgp_prefix_request is not None
                 else None
             )
+            print("Prefixes before filter: ", prefixes)
+            print("Filters: ", filters)
             return self._apply_v4_filters(prefixes, filters)
         else:
             prefixes = [

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -126,6 +126,21 @@ class Bgp(Base):
 
     # The subset this backend can translate today.  An empty prefix_filters
     # means "all supported families", so this is also the default.
+    #
+    # TODO(mpls): to add the MPLS families, three things are needed and
+    # nothing else in this file should have to change:
+    #   1. add "ipv4_mpls_unicast"/"ipv6_mpls_unicast" here, which makes
+    #      resolve_prefix_filters accept them instead of raising;
+    #   2. add their learnedInfo table Type prefixes to
+    #      _LEARNED_TABLE_FAMILIES, so rows are routed by family, and add
+    #      _FAMILY_TRANSLATION entries pointing at the row converters and
+    #      the (currently non-existent) MPLS filter lists;
+    #   3. confirm whether GetAllLearnedInfo populates the MPLS tables or
+    #      whether GetIPv4MplsLearnedInfo / GetIPv6MplsLearnedInfo must be
+    #      triggered as well -- see _get_learned_table.
+    # The response fields ipv4_mpls_unicast_prefixes /
+    # ipv6_mpls_unicast_prefixes already exist in the OTG model, and
+    # _PREFIX_FILTER_FIELDS above already maps them.
     _SUPPORTED_PREFIX_FILTERS = ("ipv4_unicast", "ipv6_unicast")
 
     # How to turn a row of each family into an OTG prefix, and which
@@ -149,9 +164,13 @@ class Bgp(Base):
     # never be compared for equality.  An MPLS table is a distinct Type and
     # therefore does not match either entry -- which is what keeps MPLS rows
     # from being reported as plain unicast prefixes.
+    #
+    # These strings double as the server-side ``Table.find(Type=...)`` regex
+    # (see _table_type_pattern), so keep them free of regex metacharacters:
+    # they are matched literally, only anchored and alternated.
     _LEARNED_TABLE_FAMILIES = (
-        ("ipv4 prefixes", "ipv4_unicast"),
-        ("ipv6 prefixes", "ipv6_unicast"),
+        ("IPv4 Prefixes", "ipv4_unicast"),
+        ("IPv6 Prefixes", "ipv6_unicast"),
     )
 
     def __init__(self, ngpf):
@@ -556,11 +575,66 @@ class Bgp(Base):
         """
         lowered = (table_type or "").strip().lower()
         for prefix, family in self._LEARNED_TABLE_FAMILIES:
-            if lowered.startswith(prefix):
+            if lowered.startswith(prefix.lower()):
                 return family
         return None
 
-    def _get_learned_table(self, peer_obj):
+    def _table_type_pattern(self, families):
+        """Return a ``Table.find(Type=...)`` regex for *families*, or ``None``.
+
+        ``find()``'s named parameters are evaluated as regular expressions on
+        the API server, so the requested families can be selected there
+        rather than fetching every table and discarding most of them.
+
+        Verified against IxNetwork 10.80: anchoring, alternation and the
+        ``(?i)`` inline flag all work, and a pattern that matches nothing
+        returns an empty result rather than raising.  The flag matters --
+        without it the server match would be case-sensitive while
+        :meth:`_table_family` is not, so the two would disagree on a table
+        type that differed only in casing.
+        """
+        prefixes = [
+            prefix
+            for prefix, family in self._LEARNED_TABLE_FAMILIES
+            if families is None or family in families
+        ]
+        if not prefixes:
+            return None
+        return "(?i)^(%s)" % "|".join(prefixes)
+
+    def _find_learned_tables(self, learned_info, families):
+        """Return ``(tables, fell_back)`` for one learnedInfo object.
+
+        The read is narrowed server-side to *families*.  When that returns
+        nothing the tables are re-read unfiltered, because an empty filtered
+        result is indistinguishable from "this peer learned no routes" -- and
+        without the re-read a table whose Type we no longer recognise would
+        produce no prefixes *and* no diagnostic.
+
+        Whether falling back indicates a problem depends on what the rows
+        turn out to be, which only the caller can see: a peer that simply
+        does not carry a requested family is the normal case and must stay
+        quiet.  So this reports the fallback and leaves the judgement to
+        :meth:`_get_learned_table`.
+        """
+        pattern = self._table_type_pattern(families)
+        if pattern is None:
+            return learned_info.Table.find(), False
+
+        try:
+            found = learned_info.Table.find(Type=pattern)
+        except Exception as e:
+            self.logger.debug(
+                "Table.find(Type=%r) unavailable, reading every table: %s"
+                % (pattern, e)
+            )
+            return learned_info.Table.find(), True
+
+        if len(found):
+            return found, False
+        return learned_info.Table.find(), True
+
+    def _get_learned_table(self, peer_obj, families=None):
         """Trigger a learned-info fetch and return its rows **by family**.
 
         ``GetAllLearnedInfo`` (not ``GetIPv4/6LearnedInfo``) is the operation
@@ -579,6 +653,10 @@ class Bgp(Base):
         ----------
         peer_obj :
             Live RestPy ``bgpIpv4Peer`` or ``bgpIpv6Peer`` object.
+        families : list[str] or None
+            Families to fetch.  Used to narrow the read server-side; ``None``
+            reads every table.  Rows are still classified by table Type, so
+            passing this is an optimisation, not a correctness requirement.
 
         Returns
         -------
@@ -588,6 +666,10 @@ class Bgp(Base):
         """
         # --- Step 1: trigger the learned-info fetch -----------------------
         # Equivalent to right-click → "Get Learned Info" in the GUI.
+        # TODO(mpls): this triggers every family IxNetwork is configured to
+        # capture.  If the MPLS families are added and their tables turn out
+        # not to be populated by this call, GetIPv4MplsLearnedInfo /
+        # GetIPv6MplsLearnedInfo have to be triggered here as well.
         try:
             peer_obj.GetAllLearnedInfo()
         except Exception as e:
@@ -599,9 +681,21 @@ class Bgp(Base):
 
         # --- Step 2: read LearnedInfo.find().Table.find() -----------------
         tables = {}
+        skipped_types = []
+        fell_back = False
+        # The unfiltered fallback read can return families that were not
+        # asked for.  Those are dropped rather than returned, so the result
+        # only ever holds requested families, and so that a table of another
+        # family is not mistaken below for an unrecognised one.
+        wanted = set(
+            families if families is not None
+            else self._SUPPORTED_PREFIX_FILTERS
+        )
         try:
             for li in peer_obj.LearnedInfo.find():
-                for table in li.Table.find():
+                found, li_fell_back = self._find_learned_tables(li, families)
+                fell_back = fell_back or li_fell_back
+                for table in found:
                     columns = table.Columns
                     if not columns:
                         continue
@@ -618,6 +712,9 @@ class Bgp(Base):
                         )
                     )
                     if family is None:
+                        skipped_types.append(table.Type)
+                        continue
+                    if family not in wanted:
                         continue
                     col_idx = {col.strip(): i for i, col in enumerate(columns)}
                     rows = tables.setdefault(family, [])
@@ -631,6 +728,40 @@ class Bgp(Base):
             self.logger.warning(
                 "_get_learned_table: Table.find() failed for peer %r: %s"
                 % (peer_obj.Name, e)
+            )
+
+        known_prefixes = [p for p, _f in self._LEARNED_TABLE_FAMILIES]
+
+        if skipped_types and not tables:
+            # Learned info was fetched and none of it could be interpreted.
+            # A peer carrying only other families (EVPN, flow spec, ...) looks
+            # the same, hence a warning rather than an error -- but if a table
+            # type is ever renamed this is the line that says so, instead of
+            # the caller silently seeing no prefixes.
+            self.logger.warning(
+                "No recognised learned-info table for peer %r; skipped "
+                "%d table(s) of unhandled type: %s. Known types start with "
+                "%s."
+                % (
+                    peer_obj.Name,
+                    len(skipped_types),
+                    sorted(set(skipped_types)),
+                    known_prefixes,
+                )
+            )
+        elif fell_back and tables:
+            # The server-side Type filter missed a table that this code then
+            # understood perfectly well.  Not expected -- the filter is built
+            # from the same prefixes, case-insensitively -- so it means the
+            # server's regex handling differs from what was verified.  Harmless
+            # here (the rows were recovered) but worth knowing about, since it
+            # is the mechanism by which a future version could start losing
+            # prefixes silently.
+            self.logger.warning(
+                "Learned-info Type filter did not match the %s table(s) for "
+                "peer %r, which were read and parsed anyway. Server-side "
+                "table filtering may not be behaving as expected."
+                % (sorted(tables), peer_obj.Name)
             )
         return tables
 
@@ -1238,7 +1369,7 @@ class Bgp(Base):
         if families is None:
             families = self._SUPPORTED_PREFIX_FILTERS
 
-        tables = self._get_learned_table(peer_obj)
+        tables = self._get_learned_table(peer_obj, families)
 
         prefixes_by_field = {}
         for family in families:

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -407,6 +407,43 @@ class Bgp(Base):
         ------
         Exception
             If any name in *peer_names* is not found in the live topology.
+
+        Limitations
+        -----------
+        Peers are found by walking the live NGPF tree rather than by looking
+        them up by name, which has three known consequences.  The same walk
+        is used by the ``ipv4_neighbors``/``ipv6_neighbors`` branches of
+        :meth:`Ngpf.get_states`, so these apply there too.
+
+        * **Cost grows with the topology.** The walk runs on every call and
+          nothing is cached between calls (the topology may have changed),
+          so a configuration with very many device groups pays for a full
+          traversal each time.
+        * **Only top-level device groups are searched.**
+          ``DeviceGroup.find()`` returns the groups directly beneath the
+          topology, not their children, so a peer in a nested ("chained")
+          device group is not found.
+        * **Only Ethernet-backed interfaces are searched.** The chain is
+          ``DeviceGroup -> Ethernet -> Ipv4/Ipv6 -> BgpIpv4Peer/BgpIpv6Peer``,
+          so a peer configured on a loopback is not found.  This is not
+          hypothetical: :class:`LoopbackInt` places each loopback in a
+          *child* device group and attaches it as ``ipv4Loopback`` /
+          ``ipv6Loopback`` (or, for a VXLAN source interface, as
+          ``ethernet/ipv4`` inside that child group), so both limitations
+          above apply to it at once.
+
+        In each of those cases a requested peer name is reported as
+        "BGP peer(s) not found in topology", which does not distinguish an
+        unsupported topology from a mistyped name.
+
+        The robust fix is to stop searching and look the peer up directly:
+        ``ixn_objects`` already maps every snappi name to an ``IxNetInfo``
+        carrying ``.xpath``/``.href``, and the object type is the trailing
+        xpath segment (``.../ipv4[1]/bgpIpv4Peer[1]``), so filtering to
+        ``bgpIpv4Peer``/``bgpIpv6Peer`` needs no new capability in
+        :class:`IxNetObjects`.  That belongs in a follow-up which also
+        converts the two neighbor paths, so all three share one lookup
+        helper instead of three hand-rolled traversals.
         """
         requested = set(peer_names) if peer_names else None
         ixn_object_names = set(self._ngpf.api.ixn_objects.names)

--- a/snappi_ixnetwork/device/bgp.py
+++ b/snappi_ixnetwork/device/bgp.py
@@ -299,6 +299,147 @@ class Bgp(Base):
                 self._ngpf.set_device_info(route, ixn_ip_pool)
                 self._configure_route(route, ixn_route)
 
+    # ------------------------------------------------------------------
+    # Learned-info helpers (used by ngpf.get_bgp_prefix_states)
+    # ------------------------------------------------------------------
+
+    def get_bgp_peer_objects(self, peer_names):
+        """Return a list of ``(peer_name, restpy_peer_obj, session_index,
+        family)`` for every BGP peer that matches *peer_names*.
+
+        Parameters
+        ----------
+        peer_names : list[str]
+            Snappi peer names to query.  An empty list means *all* configured
+            BGP peers.
+
+        Returns
+        -------
+        list of (str, restpy_obj, int, str)
+            *session_index* is 1-based (as required by
+            ``GetIPv4/6LearnedInfo``).  *family* is ``"v4"`` or ``"v6"``.
+
+        Raises
+        ------
+        Exception
+            If any name in *peer_names* is not found in the live topology.
+        """
+        requested = set(peer_names) if peer_names else None
+        ixn_object_names = set(self._ngpf.api.ixn_objects.names)
+        results = []
+
+        topologies = self._ngpf.api._ixnetwork.Topology.find()
+        bgpv4_peers = (
+            topologies.DeviceGroup.find()
+            .Ethernet.find()
+            .Ipv4.find()
+            .BgpIpv4Peer.find()
+        )
+        bgpv6_peers = (
+            topologies.DeviceGroup.find()
+            .Ethernet.find()
+            .Ipv6.find()
+            .BgpIpv6Peer.find()
+        )
+        for peer_obj in bgpv4_peers:
+            self._collect_peer_entries(
+                peer_obj, "v4", requested, ixn_object_names, results
+            )
+        for peer_obj in bgpv6_peers:
+            self._collect_peer_entries(
+                peer_obj, "v6", requested, ixn_object_names, results
+            )
+
+        if requested:
+            found = {r[0] for r in results}
+            missing = sorted(requested - found)
+            if missing:
+                raise Exception(
+                    "BGP peer(s) not found in topology: %s" % missing
+                )
+        return results
+
+    def _collect_peer_entries(
+        self, peer_obj, family, requested, ixn_object_names, results
+    ):
+        """Append ``(name, peer_obj, session_idx, family)`` to *results*.
+
+        Handles both non-compacted (single-session) and compacted
+        (multi-session scalable) peers.  For compacted peers the
+        ``ixn_objects`` entry for the root name carries the full ``names``
+        list; each name's 0-based position in that list is its session
+        index.  *session_idx* is 1-based.
+        """
+        root_name = peer_obj.Name
+        if root_name not in ixn_object_names:
+            return
+        ixn_info = self._ngpf.api.ixn_objects.get(root_name)
+        # Non-compacted peers have names=[]; treat root_name as the sole entry.
+        names = ixn_info.names if ixn_info.names else [root_name]
+        for idx, name in enumerate(names):
+            if name is None or name not in ixn_object_names:
+                continue
+            if requested is not None and name not in requested:
+                continue
+            results.append((name, peer_obj, idx + 1, family))
+
+    def _get_learned_table(self, peer_obj, session_index, family):
+        """Refresh learned-info for *session_index* and return the rows.
+
+        Calls ``GetIPv4LearnedInfo`` (or v6 equivalent) on the RestPy peer
+        object to request a data refresh from IxNetwork, then reads the
+        resulting ``LearnedInfo → Table`` hierarchy and converts each row
+        into a ``{column_name: value_str}`` dict.
+
+        Parameters
+        ----------
+        peer_obj : restpy bgpIpv4Peer or bgpIpv6Peer
+            Live RestPy peer object returned by
+            ``get_bgp_peer_objects``.
+        session_index : int
+            1-based session index within *peer_obj*.
+        family : str
+            ``"v4"`` for IPv4 unicast; ``"v6"`` for IPv6 unicast.
+
+        Returns
+        -------
+        list[dict[str, str]]
+            One dict per prefix row; keys are the IxNetwork column headers.
+            Returns an empty list when the peer is not yet started or on
+            any error.
+        """
+        try:
+            if family == "v4":
+                peer_obj.GetIPv4LearnedInfo(
+                    SessionIndices=[session_index]
+                )
+            else:
+                peer_obj.GetIPv6LearnedInfo(
+                    SessionIndices=[session_index]
+                )
+        except Exception as e:
+            self.logger.warning(
+                "GetIPv%sLearnedInfo failed for session %d: %s"
+                % ("4" if family == "v4" else "6", session_index, e)
+            )
+            return []
+
+        rows = []
+        for li in peer_obj.LearnedInfo.find():
+            for table in li.Table.find():
+                columns = table.Columns
+                if not columns:
+                    continue
+                col_idx = {col: i for i, col in enumerate(columns)}
+                for row_vals in (table.Values or []):
+                    row = {
+                        col: row_vals[i]
+                        for col, i in col_idx.items()
+                        if i < len(row_vals)
+                    }
+                    rows.append(row)
+        return rows
+
     def _configure_route(self, route, ixn_route):
         self._ngpf.set_ixn_routes(route, ixn_route)
         self.configure_multivalues(route, ixn_route, Bgp._ROUTE)

--- a/snappi_ixnetwork/device/ngpf.py
+++ b/snappi_ixnetwork/device/ngpf.py
@@ -403,12 +403,59 @@ class Ngpf(Base):
                 request.ipv6_neighbors,
                 "ipv6",
             )
+        elif request.choice == "bgp_prefixes":
+            return self.get_bgp_prefix_states(request)
         else:
             raise TypeError(
-                "get_states only accept ipv4_neighbors or ipv6_neighbors"
+                "get_states only accept ipv4_neighbors, ipv6_neighbors"
+                " or bgp_prefixes"
             )
 
         return {"choice": request.choice, request.choice: resolved_mac_list}
+
+    def get_bgp_prefix_states(self, request):
+        """Return learned BGP prefix state for all requested peers.
+
+        Implements the ``bgp_prefixes`` choice of
+        ``StatesRequest`` / ``StatesResponse`` on the IxNetwork backend.
+
+        Parameters
+        ----------
+        request : StatesRequest
+            The fully-deserialised snappi ``StatesRequest`` object whose
+            ``choice`` is ``"bgp_prefixes"``.
+
+        Returns
+        -------
+        dict
+            ``{"choice": "bgp_prefixes", "bgp_prefixes": [...]}``, where
+            each list entry is an OTG ``BgpPrefixesState`` dict.
+        """
+        bgp_prefix_req = request.bgp_prefixes
+        peer_names = bgp_prefix_req.bgp_peer_names or []
+        self.logger.debug(
+            "get_bgp_prefix_states peer_names=%s" % peer_names
+        )
+
+        peer_entries = self._bgp.get_bgp_peer_objects(peer_names)
+
+        results = []
+        for peer_name, peer_obj, session_index, family in peer_entries:
+            self.logger.debug(
+                "Fetching learned prefixes: peer=%s session=%d family=%s"
+                % (peer_name, session_index, family)
+            )
+            prefixes = self._bgp.get_learned_prefixes(
+                peer_obj, session_index, family, bgp_prefix_req
+            )
+            entry = {"bgp_peer_name": peer_name}
+            if family == "v4":
+                entry["ipv4_unicast_prefixes"] = prefixes
+            else:
+                entry["ipv6_unicast_prefixes"] = prefixes
+            results.append(entry)
+
+        return {"choice": "bgp_prefixes", "bgp_prefixes": results}
 
     def _get_ether_resolved_mac(
         self, ip_objs, ether_gateway_map, ip_neighbors, choice

--- a/snappi_ixnetwork/device/ngpf.py
+++ b/snappi_ixnetwork/device/ngpf.py
@@ -420,26 +420,6 @@ class Ngpf(Base):
 
         Implements the ``bgp_prefixes`` choice of
         ``StatesRequest`` / ``StatesResponse`` on the IxNetwork backend.
-
-        Parameters
-        ----------
-        request : StatesRequest
-            The fully-deserialised snappi ``StatesRequest`` object whose
-            ``choice`` is ``"bgp_prefixes"``.
-
-        Returns
-        -------
-        dict
-            ``{"choice": "bgp_prefixes", "bgp_prefixes": [...]}``, where
-            each list entry is an OTG ``BgpPrefixesState`` dict.  There is
-            exactly one entry per peer, carrying every requested address
-            family that peer has learned.
-
-        Raises
-        ------
-        Exception
-            If ``prefix_filters`` names a family this backend cannot
-            retrieve (see :meth:`Bgp.resolve_prefix_filters`).
         """
         bgp_prefix_req = request.bgp_prefixes
         peer_names = bgp_prefix_req.bgp_peer_names or []

--- a/snappi_ixnetwork/device/ngpf.py
+++ b/snappi_ixnetwork/device/ngpf.py
@@ -1,5 +1,7 @@
 import json, re
 
+from collections import OrderedDict
+
 from snappi_ixnetwork.timer import Timer
 from snappi_ixnetwork.device.base import Base
 from snappi_ixnetwork.device.bgp import Bgp
@@ -429,33 +431,52 @@ class Ngpf(Base):
         -------
         dict
             ``{"choice": "bgp_prefixes", "bgp_prefixes": [...]}``, where
-            each list entry is an OTG ``BgpPrefixesState`` dict.
+            each list entry is an OTG ``BgpPrefixesState`` dict.  There is
+            exactly one entry per peer, carrying every requested address
+            family that peer has learned.
+
+        Raises
+        ------
+        Exception
+            If ``prefix_filters`` names a family this backend cannot
+            retrieve (see :meth:`Bgp.resolve_prefix_filters`).
         """
         bgp_prefix_req = request.bgp_prefixes
         peer_names = bgp_prefix_req.bgp_peer_names or []
+        # prefix_filters selects the address families; the per-family
+        # ipv4/ipv6_unicast_filters are applied further down, in
+        # Bgp.get_learned_prefixes.
+        families = self._bgp.resolve_prefix_filters(
+            bgp_prefix_req.prefix_filters
+        )
         self.logger.debug(
-            "get_bgp_prefix_states peer_names=%s" % peer_names
+            "get_bgp_prefix_states peer_names=%s families=%s"
+            % (peer_names, families)
         )
 
         peer_entries = self._bgp.get_bgp_peer_objects(peer_names)
 
-        results = []
+        # Keyed by peer name so that a peer carrying more than one family
+        # yields a single BgpPrefixesState rather than one entry per family.
+        results = OrderedDict()
         for peer_name, peer_obj, session_index, family in peer_entries:
             self.logger.debug(
-                "Fetching learned prefixes: peer=%s session=%d family=%s"
+                "Fetching learned prefixes: peer=%s session=%d peer_family=%s"
                 % (peer_name, session_index, family)
             )
-            prefixes = self._bgp.get_learned_prefixes(
-                peer_obj, session_index, family, bgp_prefix_req
+            prefixes_by_field = self._bgp.get_learned_prefixes(
+                peer_obj, bgp_prefix_req, families
             )
-            entry = {"bgp_peer_name": peer_name}
-            if family == "v4":
-                entry["ipv4_unicast_prefixes"] = prefixes
-            else:
-                entry["ipv6_unicast_prefixes"] = prefixes
-            results.append(entry)
+            entry = results.setdefault(
+                peer_name, {"bgp_peer_name": peer_name}
+            )
+            for field, prefixes in prefixes_by_field.items():
+                entry.setdefault(field, []).extend(prefixes)
 
-        return {"choice": "bgp_prefixes", "bgp_prefixes": results}
+        return {
+            "choice": "bgp_prefixes",
+            "bgp_prefixes": list(results.values()),
+        }
 
     def _get_ether_resolved_mac(
         self, ip_objs, ether_gateway_map, ip_neighbors, choice

--- a/tests/bgp/test_bgp_prefix_families.py
+++ b/tests/bgp/test_bgp_prefix_families.py
@@ -1,0 +1,491 @@
+"""
+Unit tests for address-family selection in get_states(bgp_prefixes).
+
+``StatesRequest.bgp_prefixes`` carries three independent filters:
+
+  * ``prefix_filters``          -- which address families to report;
+  * ``ipv4_unicast_filters``    -- which IPv4 prefixes, within that family;
+  * ``ipv6_unicast_filters``    -- likewise for IPv6.
+
+These tests cover the first one and how it composes with the other two, plus
+the family-per-learned-table routing that makes it possible.  No chassis is
+needed: the learned-info tables are faked at the RestPy boundary.
+"""
+
+import logging
+
+import pytest
+import snappi
+
+from snappi_ixnetwork.device.bgp import Bgp
+from snappi_ixnetwork.device.ngpf import Ngpf
+
+try:  # pragma: no cover - import shape differs across Python versions
+    from unittest.mock import MagicMock
+except ImportError:  # pragma: no cover
+    from mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Fake learned-info tables
+# ---------------------------------------------------------------------------
+
+V4_COLUMNS = [
+    "IPv4 Prefix ",
+    "Prefix Length",
+    "Path ID",
+    "IPv4 Next Hop",
+    "IPv6 Next Hop",
+    "MED",
+    "Local Preference",
+    "Origin",
+    "AS Path",
+    "Community",
+]
+
+V6_COLUMNS = [
+    "IPv6 Prefix",
+    "Prefix Length",
+    "Path ID",
+    "IPv4 Next Hop",
+    "IPv6 Next Hop",
+    "MED",
+    "Local Preference",
+    "Origin",
+    "AS Path",
+    "Community",
+]
+
+
+def v4_values(address="100.1.0.0"):
+    return [
+        address,
+        "24",
+        "NA",
+        "10.1.1.1",
+        "removePacket[ ]",
+        "50",
+        "0",
+        "EGP",
+        "<100 200>",
+        "1 : 2",
+    ]
+
+
+def v6_values(address="4000::"):
+    return [
+        address,
+        "64",
+        "NA",
+        "removePacket[ ]",
+        "2001:db8::1",
+        "60",
+        "0",
+        "IGP",
+        "<500 600>",
+        "3 : 4",
+    ]
+
+
+class FakeTable(object):
+    def __init__(self, type_, columns, values):
+        self.Type = type_
+        self.Columns = columns
+        self.Values = values
+
+
+class _FindList(object):
+    """Mimics a RestPy child accessor: ``.find()`` returns the items."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def find(self, **kwargs):
+        return self._items
+
+
+class FakeLearnedInfo(object):
+    def __init__(self, tables):
+        self.Table = _FindList(tables)
+
+
+class FakePeer(object):
+    """A RestPy peer object exposing pre-baked learned-info tables."""
+
+    def __init__(self, name, tables):
+        self.Name = name
+        self.LearnedInfo = _FindList([FakeLearnedInfo(tables)])
+        self.get_all_learned_info_calls = 0
+
+    def GetAllLearnedInfo(self):
+        self.get_all_learned_info_calls += 1
+
+
+def v4_table(addresses=("100.1.0.0",), type_="IPv4 Prefixes 1"):
+    return FakeTable(
+        type_, list(V4_COLUMNS), [v4_values(a) for a in addresses]
+    )
+
+
+def v6_table(addresses=("4000::",), type_="IPv6 Prefixes 1"):
+    return FakeTable(
+        type_, list(V6_COLUMNS), [v6_values(a) for a in addresses]
+    )
+
+
+@pytest.fixture
+def bgp():
+    return Bgp(MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# resolve_prefix_filters  (R3-a, R3-c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("empty", [None, []])
+def test_empty_prefix_filters_means_all_supported_families(bgp, empty):
+    assert bgp.resolve_prefix_filters(empty) == [
+        "ipv4_unicast",
+        "ipv6_unicast",
+    ]
+
+
+@pytest.mark.parametrize(
+    "requested, expected",
+    [
+        (["ipv4_unicast"], ["ipv4_unicast"]),
+        (["ipv6_unicast"], ["ipv6_unicast"]),
+        (["ipv4_unicast", "ipv6_unicast"], ["ipv4_unicast", "ipv6_unicast"]),
+        # Order of the request must not change the order of the result.
+        (["ipv6_unicast", "ipv4_unicast"], ["ipv4_unicast", "ipv6_unicast"]),
+        # Duplicates collapse.
+        (["ipv4_unicast", "ipv4_unicast"], ["ipv4_unicast"]),
+    ],
+)
+def test_supported_prefix_filters(bgp, requested, expected):
+    assert bgp.resolve_prefix_filters(requested) == expected
+
+
+@pytest.mark.parametrize("family", ["ipv4_mpls_unicast", "ipv6_mpls_unicast"])
+def test_mpls_families_raise_rather_than_return_empty(bgp, family):
+    """An unsupported family must fail loudly.
+
+    Returning an empty list would be indistinguishable from "this peer
+    learned nothing", which is the worst possible answer to give a test
+    that is asserting on learned routes.
+    """
+    with pytest.raises(Exception) as excinfo:
+        bgp.resolve_prefix_filters([family])
+    message = str(excinfo.value)
+    assert family in message
+    assert "not supported" in message
+
+
+def test_unknown_prefix_filter_value_raises(bgp):
+    with pytest.raises(Exception) as excinfo:
+        bgp.resolve_prefix_filters(["ipv4_multicast"])
+    assert "Unknown" in str(excinfo.value)
+
+
+def test_mpls_mixed_with_supported_family_still_raises(bgp):
+    """Partial success would silently drop the family the user asked for."""
+    with pytest.raises(Exception):
+        bgp.resolve_prefix_filters(["ipv4_unicast", "ipv4_mpls_unicast"])
+
+
+def test_prefix_filter_values_cover_the_otg_enum(bgp):
+    """The known-values map must track the OTG enum, or 'Unknown' lies."""
+    enum = set(
+        snappi.snappi.BgpPrefixStateRequest._TYPES["prefix_filters"]["enum"]
+    )
+    assert set(bgp._PREFIX_FILTER_FIELDS) == enum
+
+
+# ---------------------------------------------------------------------------
+# Table type -> family  (the R4-a piece R3-b needs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "table_type, expected",
+    [
+        ("IPv4 Prefixes 1", "ipv4_unicast"),
+        ("IPv6 Prefixes 1", "ipv6_unicast"),
+        # The trailing ordinal is per-fetch and unstable, so any value of it
+        # must map the same way.
+        ("IPv4 Prefixes 2", "ipv4_unicast"),
+        ("IPv6 Prefixes 17", "ipv6_unicast"),
+        ("ipv4 prefixes", "ipv4_unicast"),
+        # Other families must NOT be claimed as unicast.
+        ("IPv4 MPLS Prefixes 1", None),
+        ("IPv6 MPLS Prefixes 1", None),
+        ("EVPN Learned Info", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_table_family(bgp, table_type, expected):
+    assert bgp._table_family(table_type) == expected
+
+
+def test_unrecognised_table_is_skipped_not_merged(bgp):
+    """An MPLS table shares the IPv4 prefix column with the unicast table.
+
+    Discriminating on table Type rather than on column presence is what
+    stops those rows being reported as plain unicast prefixes.
+    """
+    mpls = FakeTable(
+        "IPv4 MPLS Prefixes 1", list(V4_COLUMNS), [v4_values("9.9.9.0")]
+    )
+    peer = FakePeer("p", [v4_table(("100.1.0.0",)), mpls])
+
+    tables = bgp._get_learned_table(peer)
+
+    assert list(tables) == ["ipv4_unicast"]
+    assert [r["IPv4 Prefix"] for r in tables["ipv4_unicast"]] == ["100.1.0.0"]
+
+
+def test_learned_table_groups_by_family(bgp):
+    peer = FakePeer("p", [v4_table(), v6_table()])
+    tables = bgp._get_learned_table(peer)
+    assert sorted(tables) == ["ipv4_unicast", "ipv6_unicast"]
+
+
+def test_learned_table_merges_multiple_tables_of_one_family(bgp):
+    peer = FakePeer(
+        "p",
+        [
+            v4_table(("100.1.0.0",), type_="IPv4 Prefixes 1"),
+            v4_table(("200.1.0.0",), type_="IPv4 Prefixes 2"),
+        ],
+    )
+    tables = bgp._get_learned_table(peer)
+    assert [r["IPv4 Prefix"] for r in tables["ipv4_unicast"]] == [
+        "100.1.0.0",
+        "200.1.0.0",
+    ]
+
+
+def test_learned_table_survives_a_failed_trigger(bgp):
+    peer = FakePeer("p", [v4_table()])
+    peer.GetAllLearnedInfo = MagicMock(side_effect=Exception("boom"))
+    assert bgp._get_learned_table(peer) == {}
+
+
+# ---------------------------------------------------------------------------
+# get_learned_prefixes: family routing  (R3-b)
+# ---------------------------------------------------------------------------
+
+
+def test_returns_each_family_under_its_own_field(bgp):
+    peer = FakePeer("p", [v4_table(), v6_table()])
+    result = bgp.get_learned_prefixes(peer, None)
+    assert sorted(result) == [
+        "ipv4_unicast_prefixes",
+        "ipv6_unicast_prefixes",
+    ]
+    assert result["ipv4_unicast_prefixes"][0]["ipv4_address"] == "100.1.0.0"
+    assert result["ipv6_unicast_prefixes"][0]["ipv6_address"] == "4000::"
+
+
+def test_families_argument_restricts_the_result(bgp):
+    peer = FakePeer("p", [v4_table(), v6_table()])
+    result = bgp.get_learned_prefixes(peer, None, ["ipv6_unicast"])
+    assert list(result) == ["ipv6_unicast_prefixes"]
+
+
+def test_family_comes_from_the_table_not_the_peer(bgp):
+    """An MP-BGP session over IPv4 that has learned IPv6 NLRI.
+
+    The peer object is a bgpIpv4Peer, but the learned table is IPv6, so the
+    prefixes must be reported as ipv6_unicast_prefixes.  Deriving the family
+    from the peer's own IP version -- as the first implementation did --
+    dropped these entirely.
+    """
+    peer = FakePeer("bgpv4_peer1", [v6_table()])
+    result = bgp.get_learned_prefixes(peer, None)
+    assert list(result) == ["ipv6_unicast_prefixes"]
+
+
+def test_absent_family_is_omitted_rather_than_empty(bgp):
+    """A v4-only peer must not claim an empty IPv6 result."""
+    peer = FakePeer("p", [v4_table()])
+    result = bgp.get_learned_prefixes(peer, None)
+    assert list(result) == ["ipv4_unicast_prefixes"]
+
+
+def test_family_present_but_filtered_to_nothing_is_an_empty_list(bgp):
+    """Distinguishes "nothing matched the filter" from "not carried"."""
+    request = snappi.StatesRequest().bgp_prefixes
+    filt = request.ipv4_unicast_filters.add()
+    filt.addresses = ["203.0.113.0"]
+
+    peer = FakePeer("p", [v4_table()])
+    result = bgp.get_learned_prefixes(peer, request)
+    assert result["ipv4_unicast_prefixes"] == []
+
+
+def test_per_family_filters_apply_to_their_own_family(bgp):
+    """An IPv4 filter must not narrow the IPv6 result, or vice versa."""
+    request = snappi.StatesRequest().bgp_prefixes
+    filt = request.ipv4_unicast_filters.add()
+    filt.addresses = ["100.1.1.0"]
+
+    peer = FakePeer(
+        "p",
+        [
+            v4_table(("100.1.0.0", "100.1.1.0")),
+            v6_table(("4000::", "5000::")),
+        ],
+    )
+    result = bgp.get_learned_prefixes(peer, request)
+
+    assert [p["ipv4_address"] for p in result["ipv4_unicast_prefixes"]] == [
+        "100.1.1.0"
+    ]
+    assert [p["ipv6_address"] for p in result["ipv6_unicast_prefixes"]] == [
+        "4000::",
+        "5000::",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Ngpf.get_bgp_prefix_states: end-to-end wiring  (R3-a, R3-d)
+# ---------------------------------------------------------------------------
+
+
+class FakeNgpf(object):
+    """Just enough of Ngpf to drive get_bgp_prefix_states.
+
+    The method only touches ``self._bgp`` and ``self.logger``, so this avoids
+    building a whole Ngpf (and its api/session) for an offline test.
+    """
+
+    def __init__(self, bgp, peer_entries):
+        self._bgp = bgp
+        self.logger = logging.getLogger(__name__)
+        bgp.get_bgp_peer_objects = MagicMock(return_value=peer_entries)
+
+    def run(self, request):
+        return Ngpf.get_bgp_prefix_states(self, request)
+
+
+def make_request(peer_names=None, prefix_filters=None):
+    request = snappi.StatesRequest()
+    request.choice = "bgp_prefixes"
+    if peer_names is not None:
+        request.bgp_prefixes.bgp_peer_names = peer_names
+    if prefix_filters is not None:
+        request.bgp_prefixes.prefix_filters = prefix_filters
+    return request
+
+
+def test_response_shape_and_choice(bgp):
+    peer = FakePeer("peer1", [v4_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    response = ngpf.run(make_request())
+
+    assert response["choice"] == "bgp_prefixes"
+    assert len(response["bgp_prefixes"]) == 1
+    assert response["bgp_prefixes"][0]["bgp_peer_name"] == "peer1"
+
+
+def test_prefix_filters_select_the_reported_family(bgp):
+    peer = FakePeer("peer1", [v4_table(), v6_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    entry = ngpf.run(make_request(prefix_filters=["ipv4_unicast"]))[
+        "bgp_prefixes"
+    ][0]
+    assert "ipv4_unicast_prefixes" in entry
+    assert "ipv6_unicast_prefixes" not in entry
+
+    entry = ngpf.run(make_request(prefix_filters=["ipv6_unicast"]))[
+        "bgp_prefixes"
+    ][0]
+    assert "ipv6_unicast_prefixes" in entry
+    assert "ipv4_unicast_prefixes" not in entry
+
+
+def test_no_prefix_filters_reports_every_family(bgp):
+    peer = FakePeer("peer1", [v4_table(), v6_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    entry = ngpf.run(make_request())["bgp_prefixes"][0]
+    assert "ipv4_unicast_prefixes" in entry
+    assert "ipv6_unicast_prefixes" in entry
+
+
+def test_dual_stack_peer_yields_one_entry_not_two(bgp):
+    """R3-d: one BgpPrefixesState per peer, however many families."""
+    peer = FakePeer("peer1", [v4_table(), v6_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    entries = ngpf.run(make_request())["bgp_prefixes"]
+
+    assert len(entries) == 1
+    names = [e["bgp_peer_name"] for e in entries]
+    assert len(names) == len(set(names)), "duplicate bgp_peer_name entries"
+
+
+def test_repeated_peer_name_is_merged_into_one_entry(bgp):
+    """Defensive: two walk results for one name must not split the entry."""
+    peer_a = FakePeer("peer1", [v4_table(("100.1.0.0",))])
+    peer_b = FakePeer("peer1", [v6_table(("4000::",))])
+    ngpf = FakeNgpf(
+        bgp, [("peer1", peer_a, 1, "v4"), ("peer1", peer_b, 1, "v6")]
+    )
+
+    entries = ngpf.run(make_request())["bgp_prefixes"]
+
+    assert len(entries) == 1
+    assert len(entries[0]["ipv4_unicast_prefixes"]) == 1
+    assert len(entries[0]["ipv6_unicast_prefixes"]) == 1
+
+
+def test_separate_peers_keep_separate_entries(bgp):
+    ngpf = FakeNgpf(
+        bgp,
+        [
+            ("peer1", FakePeer("peer1", [v4_table()]), 1, "v4"),
+            ("peer2", FakePeer("peer2", [v4_table(("200.1.0.0",))]), 1, "v4"),
+        ],
+    )
+    entries = ngpf.run(make_request())["bgp_prefixes"]
+    assert [e["bgp_peer_name"] for e in entries] == ["peer1", "peer2"]
+
+
+def test_mpls_prefix_filter_raises_through_get_states(bgp):
+    peer = FakePeer("peer1", [v4_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    with pytest.raises(Exception) as excinfo:
+        ngpf.run(make_request(prefix_filters=["ipv4_mpls_unicast"]))
+    assert "not supported" in str(excinfo.value)
+
+
+def test_unsupported_family_is_rejected_before_querying_hardware(bgp):
+    """The error must not cost a learned-info fetch on every peer."""
+    peer = FakePeer("peer1", [v4_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    with pytest.raises(Exception):
+        ngpf.run(make_request(prefix_filters=["ipv6_mpls_unicast"]))
+    assert peer.get_all_learned_info_calls == 0
+
+
+def test_response_deserializes_into_the_otg_model(bgp):
+    """The dict handed back must survive StatesResponse.deserialize()."""
+    peer = FakePeer("peer1", [v4_table(), v6_table()])
+    ngpf = FakeNgpf(bgp, [("peer1", peer, 1, "v4")])
+
+    response = snappi.StatesResponse()
+    response.deserialize(ngpf.run(make_request()))
+    response.serialize()
+
+    state = response.bgp_prefixes[0]
+    assert state.bgp_peer_name == "peer1"
+    assert state.ipv4_unicast_prefixes[0].ipv4_address == "100.1.0.0"
+    assert state.ipv6_unicast_prefixes[0].ipv6_address == "4000::"

--- a/tests/bgp/test_bgp_prefix_families.py
+++ b/tests/bgp/test_bgp_prefix_families.py
@@ -553,7 +553,7 @@ def test_per_family_filters_apply_to_their_own_family(bgp):
 
 
 # ---------------------------------------------------------------------------
-# Ngpf.get_bgp_prefix_states: end-to-end wiring  (R3-a, R3-d)
+# Ngpf.get_bgp_prefix_states: end-to-end wiring  
 # ---------------------------------------------------------------------------
 
 

--- a/tests/bgp/test_bgp_prefix_families.py
+++ b/tests/bgp/test_bgp_prefix_families.py
@@ -13,6 +13,7 @@ needed: the learned-info tables are faked at the RestPy boundary.
 """
 
 import logging
+import re
 
 import pytest
 import snappi
@@ -104,18 +105,56 @@ class _FindList(object):
         return self._items
 
 
+class _TableFindList(object):
+    """``learnedInfo.Table`` accessor that honours ``find(Type=<regex>)``.
+
+    RestPy evaluates ``find()``'s named parameters as regular expressions on
+    the API server; this reproduces that so the server-side narrowing is
+    actually exercised rather than silently bypassed.  ``patterns`` records
+    every Type regex requested, and ``raise_on_type`` simulates a server that
+    rejects the filtered query.
+    """
+
+    def __init__(self, tables, raise_on_type=False):
+        self._tables = tables
+        self.patterns = []
+        self.unfiltered_calls = 0
+        self.raise_on_type = raise_on_type
+
+    def find(self, **kwargs):
+        pattern = kwargs.get("Type")
+        if pattern is None:
+            self.unfiltered_calls += 1
+            return list(self._tables)
+        self.patterns.append(pattern)
+        if self.raise_on_type:
+            raise Exception("server rejected Type filter")
+        return [
+            t
+            for t in self._tables
+            if t.Type is not None and re.match(pattern, t.Type)
+        ]
+
+
 class FakeLearnedInfo(object):
-    def __init__(self, tables):
-        self.Table = _FindList(tables)
+    def __init__(self, tables, raise_on_type=False):
+        self.Table = _TableFindList(tables, raise_on_type=raise_on_type)
 
 
 class FakePeer(object):
     """A RestPy peer object exposing pre-baked learned-info tables."""
 
-    def __init__(self, name, tables):
+    def __init__(self, name, tables, raise_on_type=False):
         self.Name = name
-        self.LearnedInfo = _FindList([FakeLearnedInfo(tables)])
+        self._learned_info = FakeLearnedInfo(
+            tables, raise_on_type=raise_on_type
+        )
+        self.LearnedInfo = _FindList([self._learned_info])
         self.get_all_learned_info_calls = 0
+
+    @property
+    def table_finder(self):
+        return self._learned_info.Table
 
     def GetAllLearnedInfo(self):
         self.get_all_learned_info_calls += 1
@@ -271,6 +310,169 @@ def test_learned_table_survives_a_failed_trigger(bgp):
     peer = FakePeer("p", [v4_table()])
     peer.GetAllLearnedInfo = MagicMock(side_effect=Exception("boom"))
     assert bgp._get_learned_table(peer) == {}
+
+
+# ---------------------------------------------------------------------------
+# Server-side table selection  (R4-d)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "families, expected_families",
+    [
+        (["ipv4_unicast"], ["ipv4_unicast"]),
+        (["ipv6_unicast"], ["ipv6_unicast"]),
+        (["ipv4_unicast", "ipv6_unicast"], ["ipv4_unicast", "ipv6_unicast"]),
+    ],
+)
+def test_only_requested_families_are_fetched(bgp, families, expected_families):
+    """The requested families are selected on the server, not locally."""
+    peer = FakePeer("p", [v4_table(), v6_table()])
+
+    tables = bgp._get_learned_table(peer, families)
+
+    assert sorted(tables) == sorted(expected_families)
+    # The narrowing really happened server-side: a Type regex was sent, and
+    # no unfiltered read was needed.
+    assert peer.table_finder.patterns, "no server-side Type filter was sent"
+    assert peer.table_finder.unfiltered_calls == 0
+
+
+def test_type_pattern_is_anchored_alternated_and_case_insensitive(bgp):
+    assert bgp._table_type_pattern(["ipv4_unicast"]) == "(?i)^(IPv4 Prefixes)"
+    assert bgp._table_type_pattern(None) == (
+        "(?i)^(IPv4 Prefixes|IPv6 Prefixes)"
+    )
+    # A family with no table mapping cannot be narrowed server-side.
+    assert bgp._table_type_pattern(["ipv4_mpls_unicast"]) is None
+
+
+def test_type_pattern_matches_the_real_table_types(bgp):
+    """Guards the regex against the captured 10.80 Type strings."""
+    pattern = bgp._table_type_pattern(None)
+    for table_type in ("IPv4 Prefixes 1", "IPv6 Prefixes 17"):
+        assert re.match(pattern, table_type), table_type
+    for table_type in ("IPv4 MPLS Prefixes 1", "EVPN Learned Info"):
+        assert not re.match(pattern, table_type), table_type
+
+
+def test_unfilterable_families_read_every_table(bgp):
+    """With no server-side pattern available, fall back to reading all."""
+    peer = FakePeer("p", [v4_table()])
+    bgp._get_learned_table(peer, ["ipv4_mpls_unicast"])
+    assert peer.table_finder.patterns == []
+    assert peer.table_finder.unfiltered_calls == 1
+
+
+def test_falls_back_to_unfiltered_read_when_type_filter_raises(bgp):
+    """A server that rejects the filter must not cost us the data."""
+    peer = FakePeer("p", [v4_table(), v6_table()], raise_on_type=True)
+
+    tables = bgp._get_learned_table(peer, ["ipv4_unicast", "ipv6_unicast"])
+
+    assert sorted(tables) == ["ipv4_unicast", "ipv6_unicast"]
+    assert peer.table_finder.unfiltered_calls == 1
+
+
+def test_renamed_table_type_is_reported_not_silently_empty(bgp, caplog):
+    """Tables exist but none map to a family: the schema-drift signal.
+
+    The filtered read comes back empty, the unfiltered re-read finds the
+    table, and nothing can be made of it -- so the caller gets a warning
+    naming the type rather than an empty result and no explanation.
+    """
+    renamed = FakeTable(
+        "IPv4 Unicast Routes 1", list(V4_COLUMNS), [v4_values()]
+    )
+    peer = FakePeer("p", [renamed])
+
+    with caplog.at_level(logging.WARNING):
+        tables = bgp._get_learned_table(peer, ["ipv4_unicast"])
+
+    assert tables == {}
+    assert peer.table_finder.unfiltered_calls == 1
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "IPv4 Unicast Routes 1" in messages
+    assert "unhandled type" in messages
+
+
+def test_case_differing_table_type_is_still_matched(bgp, caplog):
+    """The server pattern is case-insensitive, matching _table_family.
+
+    The '(?i)' flag is verified to work on IxNetwork 10.80, so a type that
+    differs only in casing is selected server-side with no re-read.
+    """
+    peer = FakePeer("p", [v4_table(type_="ipv4 prefixes 1")])
+
+    with caplog.at_level(logging.WARNING):
+        tables = bgp._get_learned_table(peer, ["ipv4_unicast"])
+
+    assert list(tables) == ["ipv4_unicast"]
+    assert peer.table_finder.unfiltered_calls == 0
+    assert caplog.records == []
+
+
+def test_requesting_a_family_the_peer_lacks_is_quiet(bgp, caplog):
+    """The normal narrowed case: asking a v6 peer for IPv4.
+
+    The filter correctly matches nothing, so there is nothing to report.  An
+    earlier version warned here, which fired on every such request.
+    """
+    peer = FakePeer("p", [v6_table()])
+
+    with caplog.at_level(logging.WARNING):
+        tables = bgp._get_learned_table(peer, ["ipv4_unicast"])
+
+    assert tables == {}
+    assert caplog.records == [], "narrowing to an absent family must be quiet"
+
+
+def test_fallback_that_recovers_data_warns(bgp, caplog):
+    """If the server filter misbehaves, say so -- but keep the rows."""
+    peer = FakePeer("p", [v4_table()], raise_on_type=True)
+
+    with caplog.at_level(logging.WARNING):
+        tables = bgp._get_learned_table(peer, ["ipv4_unicast"])
+
+    assert list(tables) == ["ipv4_unicast"]
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "may not be behaving as expected" in messages
+
+
+def test_no_tables_at_all_does_not_warn(bgp, caplog):
+    """A peer that has simply learned nothing is not an anomaly."""
+    peer = FakePeer("p", [])
+    with caplog.at_level(logging.WARNING):
+        assert bgp._get_learned_table(peer, ["ipv4_unicast"]) == {}
+    assert caplog.records == []
+
+
+def test_only_unrecognised_tables_warns(bgp, caplog):
+    """Understood nothing we fetched -- the schema-drift signal."""
+    peer = FakePeer(
+        "p",
+        [FakeTable("EVPN Learned Info", list(V4_COLUMNS), [v4_values()])],
+    )
+    with caplog.at_level(logging.WARNING):
+        assert bgp._get_learned_table(peer, None) == {}
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "unhandled type" in messages
+    assert "EVPN Learned Info" in messages
+
+
+def test_recognised_plus_unrecognised_does_not_warn(bgp, caplog):
+    """A peer carrying other families as well is normal, not a problem."""
+    peer = FakePeer(
+        "p",
+        [
+            v4_table(),
+            FakeTable("EVPN Learned Info", list(V4_COLUMNS), [v4_values()]),
+        ],
+    )
+    with caplog.at_level(logging.WARNING):
+        tables = bgp._get_learned_table(peer, None)
+    assert list(tables) == ["ipv4_unicast"]
+    assert caplog.records == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bgp/test_bgp_prefix_parsers.py
+++ b/tests/bgp/test_bgp_prefix_parsers.py
@@ -160,7 +160,7 @@ def segments(as_path):
 
 
 # ---------------------------------------------------------------------------
-# _parse_as_path  (R6-b, R6-c)
+# _parse_as_path  
 # ---------------------------------------------------------------------------
 
 
@@ -320,7 +320,7 @@ def test_parse_as_path_valid_asns_never_warn(bgp, caplog):
 
 
 # ---------------------------------------------------------------------------
-# _parse_communities  (R6-d)
+# _parse_communities  
 # ---------------------------------------------------------------------------
 
 
@@ -472,7 +472,7 @@ def test_parse_communities_valid_never_warn(bgp, caplog):
 
 
 # ---------------------------------------------------------------------------
-# _row_to_ipv4_prefix / _row_to_ipv6_prefix  (R6-g)
+# _row_to_ipv4_prefix / _row_to_ipv6_prefix
 # ---------------------------------------------------------------------------
 
 
@@ -687,10 +687,6 @@ def test_path_id_present_when_set(bgp):
         ("egp", "egp"),
         ("Igp", "igp"),
         ("INCOMPLETE", "incomplete"),
-        # Single-char forms are unused on 10.80 but still mapped.
-        ("i", "igp"),
-        ("e", "egp"),
-        ("?", "incomplete"),
     ],
 )
 def test_origin_mapping(bgp, origin_cell, expected):

--- a/tests/bgp/test_bgp_prefix_parsers.py
+++ b/tests/bgp/test_bgp_prefix_parsers.py
@@ -1,0 +1,955 @@
+"""
+Unit tests for the get_states(bgp_prefixes) learned-info parsers.
+
+"""
+import logging
+
+import pytest
+import snappi
+
+from snappi_ixnetwork.device.bgp import Bgp
+
+
+try:  # pragma: no cover - import shape differs across Python versions
+    from unittest.mock import MagicMock
+except ImportError:  # pragma: no cover
+    from mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Captured fixture data (IxNetwork 10.80.8001.21)
+# ---------------------------------------------------------------------------
+
+CAPTURED_V4_COLUMNS = [
+    "IPv4 Prefix ",  # trailing space is intentional - real IxNetwork output
+    "Prefix Length",
+    "Path ID",
+    "IPv4 Next Hop",
+    "IPv6 Next Hop",
+    "IPv6 Next Hop 2",
+    "MED",
+    "Local Preference",
+    "Origin",
+    "AS Path",
+    "Community",
+    "AIGP",
+    "Color",
+    "Large Community",
+    "SRv6 SID",
+    "Locator Block Length",
+    "Locator Node Length",
+    "Function Length",
+    "Argument Length",
+]
+
+CAPTURED_V4_ROW = [
+    "100.1.0.0",
+    "24",
+    "NA",
+    "10.1.1.1",
+    "removePacket[ ]",
+    "removePacket[ ]",
+    "50",
+    "0",
+    "EGP",
+    "<100 200>",
+    "1 : 2",
+    "",
+    "",
+    "NA",
+    "NA",
+    "NA",
+    "NA",
+    "NA",
+    "NA",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bgp():
+    """A Bgp instance with a stubbed ngpf -- the parsers never touch it."""
+    return Bgp(MagicMock())
+
+
+def make_row(columns, values):
+    """Build a row dict the way _get_learned_table does (stripped keys)."""
+    return {
+        col.strip(): values[i]
+        for i, col in enumerate(columns)
+        if i < len(values)
+    }
+
+
+@pytest.fixture
+def captured_v4_row():
+    return make_row(CAPTURED_V4_COLUMNS, CAPTURED_V4_ROW)
+
+
+def v4_row(**overrides):
+    """A minimal-but-complete IPv4 row, with per-test column overrides.
+
+    Passing ``None`` as a value removes the column entirely, which is how
+    "IxNetwork stopped emitting this column" is simulated.
+    """
+    row = {
+        "IPv4 Prefix": "100.1.0.0",
+        "Prefix Length": "24",
+        "Path ID": "NA",
+        "IPv4 Next Hop": "10.1.1.1",
+        "IPv6 Next Hop": "removePacket[ ]",
+        "MED": "50",
+        "Local Preference": "0",
+        "Origin": "EGP",
+        "AS Path": "<100 200>",
+        "Community": "1 : 2",
+    }
+    for key, value in overrides.items():
+        if value is None:
+            row.pop(key, None)
+        else:
+            row[key] = value
+    return row
+
+
+def v6_row(**overrides):
+    """A minimal-but-complete IPv6 row (column names UNCONFIRMED)."""
+    row = {
+        "IPv6 Prefix": "4000::",
+        "Prefix Length": "64",
+        "Path ID": "NA",
+        "IPv6 Next Hop": "2000::1",
+        "IPv4 Next Hop": "removePacket[ ]",
+        "MED": "60",
+        "Local Preference": "100",
+        "Origin": "IGP",
+        "AS Path": "<500 600>",
+        "Community": "3 : 4",
+    }
+    for key, value in overrides.items():
+        if value is None:
+            row.pop(key, None)
+        else:
+            row[key] = value
+    return row
+
+
+def make_filter(family="ipv4", **kwargs):
+    """Build a real snappi unicast filter so field names stay honest.
+
+    A hand-rolled stub would keep passing if the OTG model renamed a
+    filter field; the real object will not.
+    """
+    request = snappi.StatesRequest()
+    filters = getattr(
+        request.bgp_prefixes, "%s_unicast_filters" % family
+    )
+    filt = filters.add()
+    for name, value in kwargs.items():
+        setattr(filt, name, value)
+    return filt
+
+
+def segments(as_path):
+    """Flatten a parsed as_path into ``[(type, [asn, ...]), ...]``."""
+    return [(s["type"], s["as_numbers"]) for s in as_path["segments"]]
+
+
+# ---------------------------------------------------------------------------
+# _parse_as_path  (R6-b, R6-c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        # The bracketed asplain form IxNetwork 10.80 actually emits.
+        ("<100 200>", [("as_seq", [100, 200])]),
+        # Unbracketed sequence (older/other IxNetwork output).
+        ("100 200 300", [("as_seq", [100, 200, 300])]),
+        # All four OTG segment types, one per bracket style.
+        ("<100>", [("as_seq", [100])]),
+        ("{100 200}", [("as_set", [100, 200])]),
+        ("(100 200)", [("as_confed_seq", [100, 200])]),
+        ("[100 200]", [("as_confed_set", [100, 200])]),
+        # Mixed: a group followed by loose ASNs, and the reverse.  Segment
+        # order must follow the string, not the parser's buffering.
+        (
+            "{100 200} 300",
+            [("as_set", [100, 200]), ("as_seq", [300])],
+        ),
+        (
+            "300 {100 200}",
+            [("as_seq", [300]), ("as_set", [100, 200])],
+        ),
+        (
+            "(100 200) [300]",
+            [("as_confed_seq", [100, 200]), ("as_confed_set", [300])],
+        ),
+        (
+            "100 {200} 300",
+            [
+                ("as_seq", [100]),
+                ("as_set", [200]),
+                ("as_seq", [300]),
+            ],
+        ),
+        ("<100> <200>", [("as_seq", [100]), ("as_seq", [200])]),
+        # 2-byte and 4-byte AS numbers (asplain), including the uint32 max.
+        ("65535", [("as_seq", [65535])]),
+        ("4200000000", [("as_seq", [4200000000])]),
+        ("<4294967295>", [("as_seq", [4294967295])]),
+        # Empty / sentinel cells yield no segments rather than a segment
+        # with no members.
+        ("", []),
+        ("   ", []),
+        ("N/A", []),
+        ("n/a", []),
+        ("0", []),
+        # An unterminated group is recovered rather than dropped.
+        ("<100 200", [("as_seq", [100, 200])]),
+    ],
+)
+def test_parse_as_path(bgp, cell, expected):
+    assert segments(bgp._parse_as_path(cell)) == expected
+
+
+def test_parse_as_path_none_cell(bgp):
+    """_get_cell returns None for an absent/placeholder column."""
+    assert bgp._parse_as_path(None) == {"segments": []}
+
+
+# The verbatim AS Path cell from an eBGP peer on 10.80 advertising three
+# configured segments.  Two things this pins down, both found on hardware
+# after the first version of these tests guessed wrong:
+#   * AS_SET members are COMMA-separated ('{300,400}') while AS_SEQ members
+#     are space-separated -- the separator differs by segment type;
+#   * the advertising peer prepends its own AS (4200000001) as a separate
+#     leading AS_SEQ segment over eBGP.
+CAPTURED_EBGP_AS_PATH = "<4200000001> <100 200> {300,400} <4200000000>"
+
+
+def test_parse_captured_ebgp_as_path(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        result = bgp._parse_as_path(CAPTURED_EBGP_AS_PATH)
+    assert segments(result) == [
+        ("as_seq", [4200000001]),
+        ("as_seq", [100, 200]),
+        ("as_set", [300, 400]),
+        ("as_seq", [4200000000]),
+    ]
+    assert caplog.records == [], "real IxNetwork output must parse cleanly"
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        # Comma-separated members, with and without spaces.  '{300,400}' is
+        # the real 10.80 AS_SET rendering.
+        ("{300,400}", [("as_set", [300, 400])]),
+        ("{300, 400}", [("as_set", [300, 400])]),
+        ("<100,200>", [("as_seq", [100, 200])]),
+        ("(100,200)", [("as_confed_seq", [100, 200])]),
+        ("[100,200]", [("as_confed_set", [100, 200])]),
+        # Unbracketed, comma-separated.
+        ("100,200", [("as_seq", [100, 200])]),
+        # Trailing/repeated separators must not produce phantom entries.
+        ("{300,400,}", [("as_set", [300, 400])]),
+        ("{300,,400}", [("as_set", [300, 400])]),
+    ],
+)
+def test_parse_as_path_comma_separated_members(bgp, caplog, cell, expected):
+    with caplog.at_level(logging.WARNING):
+        assert segments(bgp._parse_as_path(cell)) == expected
+    assert caplog.records == []
+
+
+def test_parse_as_path_empty_group_is_kept(bgp):
+    """Documents current behaviour: '{}' yields an empty as_set segment.
+
+    Harmless for consumers (the segment simply has no members) but recorded
+    here so a future change to drop empty segments is a deliberate one.
+    """
+    assert segments(bgp._parse_as_path("{}")) == [("as_set", [])]
+
+
+@pytest.mark.parametrize(
+    "cell, kept",
+    [
+        # asdot is deliberately NOT converted: IxNetwork has only ever been
+        # observed emitting asplain, and ixnetwork_restpy exposes no asdot
+        # setting.  The token must be dropped *loudly*.
+        ("<1.10 200>", [200]),
+        # Out-of-range for uint32.
+        ("<4294967296>", []),
+        # Non-numeric junk.  (A comma-separated list is NOT junk -- see
+        # test_parse_as_path_comma_separated_members.)
+        ("<abc 200>", [200]),
+        ("<100;200>", []),
+    ],
+)
+def test_parse_as_path_bad_tokens_warn_not_silent(bgp, caplog, cell, kept):
+    """A token that cannot be parsed must produce a warning, never silence.
+
+    Silently dropping an ASN turns a format surprise into a wrong AS path,
+    and AS-path assertions are the main reason these states exist.
+    """
+    with caplog.at_level(logging.WARNING):
+        result = bgp._parse_as_path(cell)
+    assert segments(result)[0][1] == kept
+    assert caplog.records, "unparseable AS token was dropped silently"
+
+
+def test_parse_as_path_asdot_warning_names_the_conversion(bgp, caplog):
+    """The asdot warning must tell the reader how to implement it."""
+    with caplog.at_level(logging.WARNING):
+        bgp._parse_as_path("<1.10>")
+    message = " ".join(r.getMessage() for r in caplog.records)
+    assert "asdot" in message
+    assert "65536" in message
+
+
+def test_parse_as_path_valid_asns_never_warn(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        bgp._parse_as_path("{100 200} 300 <4294967295>")
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_communities  (R6-d)
+# ---------------------------------------------------------------------------
+
+
+def manual(as_number, as_custom):
+    return {
+        "type": "manual_as_number",
+        "as_number": as_number,
+        "as_custom": as_custom,
+    }
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        # The spaced form IxNetwork 10.80 actually emits.
+        ("1 : 2", [manual(1, 2)]),
+        ("1:2", [manual(1, 2)]),
+        ("1:2 3:4", [manual(1, 2), manual(3, 4)]),
+        ("1 : 2 3 : 4", [manual(1, 2), manual(3, 4)]),
+        # Boundary values: both fields are capped at 65535 by OTG.
+        ("0:0", [manual(0, 0)]),
+        ("65535:65535", [manual(65535, 65535)]),
+        # Every well-known type in the OTG enum, in the spellings the
+        # parser accepts, plus a case-insensitivity check.
+        ("no-export", [{"type": "no_export"}]),
+        ("noexport", [{"type": "no_export"}]),
+        ("NO-EXPORT", [{"type": "no_export"}]),
+        ("no-advertise", [{"type": "no_advertised"}]),
+        ("noadvertise", [{"type": "no_advertised"}]),
+        ("no-advertised", [{"type": "no_advertised"}]),
+        ("no_export_subconfed", [{"type": "no_export_subconfed"}]),
+        ("no-export-subconfed", [{"type": "no_export_subconfed"}]),
+        ("llgr_stale", [{"type": "llgr_stale"}]),
+        ("no_llgr", [{"type": "no_llgr"}]),
+        # Mixed well-known and numeric in one cell.
+        (
+            "1:2 no-export",
+            [manual(1, 2), {"type": "no_export"}],
+        ),
+        # Empty / sentinel cells.
+        ("", []),
+        ("N/A", []),
+        ("n/a", []),
+    ],
+)
+def test_parse_communities(bgp, cell, expected):
+    assert bgp._parse_communities(cell) == expected
+
+
+def test_parse_communities_none_cell(bgp):
+    assert bgp._parse_communities(None) == []
+
+
+# The verbatim Community cell from the same eBGP capture.  Pins down that
+# the list is COMMA-separated and that well-known names come back uppercase
+# with underscores ('NO_EXPORT'), neither of which the first version of the
+# parser handled.
+CAPTURED_EBGP_COMMUNITY = "1 : 2, NO_EXPORT, 65535 : 65535"
+
+
+def test_parse_captured_ebgp_communities(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        result = bgp._parse_communities(CAPTURED_EBGP_COMMUNITY)
+    assert result == [
+        manual(1, 2),
+        {"type": "no_export"},
+        manual(65535, 65535),
+    ]
+    assert caplog.records == [], "real IxNetwork output must parse cleanly"
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        # Comma-separated, the real 10.80 rendering.
+        ("1:2,3:4", [manual(1, 2), manual(3, 4)]),
+        ("1:2, 3:4", [manual(1, 2), manual(3, 4)]),
+        ("1 : 2, 3 : 4", [manual(1, 2), manual(3, 4)]),
+        # Trailing/repeated separators must not produce phantom entries.
+        ("1:2,", [manual(1, 2)]),
+        ("1:2,,3:4", [manual(1, 2), manual(3, 4)]),
+        # Uppercase / underscore spellings, as emitted on 10.80.
+        ("NO_EXPORT", [{"type": "no_export"}]),
+        ("NO_ADVERTISED", [{"type": "no_advertised"}]),
+        ("NO_EXPORT_SUBCONFED", [{"type": "no_export_subconfed"}]),
+        ("LLGR_STALE", [{"type": "llgr_stale"}]),
+        ("NO_LLGR", [{"type": "no_llgr"}]),
+        # Mixed comma-separated well-known and manual entries.
+        (
+            "NO_EXPORT, 1 : 2",
+            [{"type": "no_export"}, manual(1, 2)],
+        ),
+    ],
+)
+def test_parse_communities_comma_separated(bgp, caplog, cell, expected):
+    with caplog.at_level(logging.WARNING):
+        assert bgp._parse_communities(cell) == expected
+    assert caplog.records == []
+
+
+def test_parse_communities_covers_every_otg_type(bgp):
+    """Guard against the OTG enum growing past what the parser handles."""
+    produced = set()
+    for cell in (
+        "1:2",
+        "no-export",
+        "no-advertise",
+        "no_export_subconfed",
+        "llgr_stale",
+        "no_llgr",
+    ):
+        produced.update(c["type"] for c in bgp._parse_communities(cell))
+    expected = set(
+        snappi.snappi.ResultBgpCommunity._TYPES["type"]["enum"]
+    )
+    assert produced == expected
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        # Large community 'X:Y:Z' -- int('Y:Z') fails.
+        "1:2:3",
+        # Not a pair and not a well-known name.
+        "garbage",
+        # Out of range: emitting these would raise at snappi serialisation
+        # time and fail the entire get_states call.
+        "65536:1",
+        "1:65536",
+    ],
+)
+def test_parse_communities_bad_tokens_warn_and_skip(bgp, caplog, cell):
+    with caplog.at_level(logging.WARNING):
+        assert bgp._parse_communities(cell) == []
+    assert caplog.records, "unparseable community was dropped silently"
+
+
+def test_parse_communities_bad_token_does_not_lose_good_ones(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        result = bgp._parse_communities("1:2 garbage 3:4")
+    assert result == [manual(1, 2), manual(3, 4)]
+    assert caplog.records
+
+
+def test_parse_communities_valid_never_warn(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        bgp._parse_communities("1 : 2 no-export 65535:65535")
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# _row_to_ipv4_prefix / _row_to_ipv6_prefix  (R6-g)
+# ---------------------------------------------------------------------------
+
+
+def test_captured_row_maps_completely(bgp, captured_v4_row, caplog):
+    """The real 10.80 row must translate with no warnings at all."""
+    with caplog.at_level(logging.WARNING):
+        prefix = bgp._row_to_ipv4_prefix(captured_v4_row)
+
+    assert prefix == {
+        "ipv4_address": "100.1.0.0",
+        "prefix_length": 24,
+        "ipv4_next_hop": "10.1.1.1",
+        "origin": "egp",
+        "local_preference": 0,
+        "multi_exit_discriminator": 50,
+        "as_path": {
+            "segments": [{"type": "as_seq", "as_numbers": [100, 200]}]
+        },
+        "communities": [manual(1, 2)],
+    }
+    # 'NA' Path ID must not become path_id=0, and the
+    # 'removePacket[ ]' IPv6 next hop must not be emitted as an address.
+    assert "path_id" not in prefix
+    assert "ipv6_next_hop" not in prefix
+    assert caplog.records == [], "captured row should need no warnings"
+
+
+def test_captured_ebgp_row_maps_completely(bgp, caplog):
+    """The verbatim eBGP row: comma separators, NO_EXPORT, title-case origin.
+
+    Every value here is exactly what IxNetwork 10.80 returned; this is the
+    row that broke the first version of the parsers.
+    """
+    row = v4_row(
+        **{
+            "AS Path": CAPTURED_EBGP_AS_PATH,
+            "Community": CAPTURED_EBGP_COMMUNITY,
+            "Origin": "Incomplete",
+            "MED": "70",
+            "Local Preference": "removePacket[N/A]",
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        prefix = bgp._row_to_ipv4_prefix(row)
+
+    assert prefix["origin"] == "incomplete"
+    assert prefix["multi_exit_discriminator"] == 70
+    # eBGP does not propagate LOCAL_PREF, so the cell is a placeholder.
+    assert "local_preference" not in prefix
+    assert [
+        (s["type"], s["as_numbers"]) for s in prefix["as_path"]["segments"]
+    ] == [
+        ("as_seq", [4200000001]),
+        ("as_seq", [100, 200]),
+        ("as_set", [300, 400]),
+        ("as_seq", [4200000000]),
+    ]
+    assert prefix["communities"] == [
+        manual(1, 2),
+        {"type": "no_export"},
+        manual(65535, 65535),
+    ]
+    assert caplog.records == [], "real IxNetwork row must parse cleanly"
+
+
+def test_captured_row_v6_handler_returns_none(bgp, captured_v4_row, caplog):
+    """A v4 row offered to the v6 handler is skipped, quietly.
+
+    Until the learned table is selected by ``table.Type``, both handlers see
+    every row, so a cross-family miss is expected and must not warn.
+    """
+    with caplog.at_level(logging.WARNING):
+        assert bgp._row_to_ipv6_prefix(captured_v4_row) is None
+    assert caplog.records == []
+
+
+def test_v6_row_maps_completely(bgp, caplog):
+    with caplog.at_level(logging.WARNING):
+        prefix = bgp._row_to_ipv6_prefix(v6_row())
+
+    assert prefix == {
+        "ipv6_address": "4000::",
+        "prefix_length": 64,
+        "ipv6_next_hop": "2000::1",
+        "origin": "igp",
+        "local_preference": 100,
+        "multi_exit_discriminator": 60,
+        "as_path": {
+            "segments": [{"type": "as_seq", "as_numbers": [500, 600]}]
+        },
+        "communities": [manual(3, 4)],
+    }
+    assert "ipv4_next_hop" not in prefix
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize(
+    "address, length_cell, expected_addr, expected_len",
+    [
+        # Bare address plus a separate Prefix Length column (10.80).
+        ("100.1.0.0", "24", "100.1.0.0", 24),
+        # Full CIDR in the address column (other IxNetwork versions).
+        ("100.1.0.0/24", "24", "100.1.0.0", 24),
+        # CIDR wins over the separate column when they disagree.
+        ("100.1.0.0/25", "24", "100.1.0.0", 25),
+        # Unparseable length degrades to 0 rather than raising.
+        ("100.1.0.0", "junk", "100.1.0.0", 0),
+    ],
+)
+def test_v4_address_and_prefix_length(
+    bgp, address, length_cell, expected_addr, expected_len
+):
+    prefix = bgp._row_to_ipv4_prefix(
+        v4_row(**{"IPv4 Prefix": address, "Prefix Length": length_cell})
+    )
+    assert prefix["ipv4_address"] == expected_addr
+    assert prefix["prefix_length"] == expected_len
+
+
+def test_v6_cidr_in_address_column(bgp):
+    prefix = bgp._row_to_ipv6_prefix(
+        v6_row(**{"IPv6 Prefix": "4000::/64"})
+    )
+    assert prefix["ipv6_address"] == "4000::"
+    assert prefix["prefix_length"] == 64
+
+
+def test_v6_link_local_second_next_hop_is_not_mapped(bgp):
+    """'IPv6 Next Hop 2' carries the link-local address on real hardware.
+
+    It is genuine data, not a placeholder, but OTG has no field for a second
+    next hop -- so it must not leak into ipv6_next_hop.
+    """
+    prefix = bgp._row_to_ipv6_prefix(
+        v6_row(
+            **{
+                "IPv6 Next Hop": "2001:db8::1",
+                "IPv6 Next Hop 2": "fe80::200:ff:fe00:11",
+            }
+        )
+    )
+    assert prefix["ipv6_next_hop"] == "2001:db8::1"
+
+
+def test_whitespace_only_community_is_empty(bgp, caplog):
+    """An empty Community column arrives as a single space on 10.80."""
+    with caplog.at_level(logging.WARNING):
+        prefix = bgp._row_to_ipv6_prefix(v6_row(**{"Community": " "}))
+    assert prefix["communities"] == []
+    assert caplog.records == []
+
+
+def test_missing_address_column_returns_none(bgp):
+    assert bgp._row_to_ipv4_prefix(v4_row(**{"IPv4 Prefix": None})) is None
+    assert bgp._row_to_ipv6_prefix(v6_row(**{"IPv6 Prefix": None})) is None
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "NA",
+        "N/A",
+        "",
+        "removePacket[ ]",
+        # Seen on 'Local Preference' for an eBGP peer, where LOCAL_PREF is
+        # not propagated: the bracketed part varies, hence prefix matching.
+        "removePacket[N/A]",
+        "removePacket[]",
+    ],
+)
+def test_placeholder_optional_fields_are_omitted(bgp, placeholder):
+    """A placeholder must omit the field, not coerce it to 0."""
+    prefix = bgp._row_to_ipv4_prefix(
+        v4_row(
+            **{
+                "MED": placeholder,
+                "Local Preference": placeholder,
+                "Path ID": placeholder,
+                "Origin": placeholder,
+            }
+        )
+    )
+    assert "multi_exit_discriminator" not in prefix
+    assert "local_preference" not in prefix
+    assert "path_id" not in prefix
+    assert "origin" not in prefix
+
+
+def test_zero_valued_fields_are_kept(bgp):
+    """0 is data, not absence -- local_preference 0 is in the real capture.
+
+    path_id is the documented exception: '0' means "no add-path ID".
+    """
+    prefix = bgp._row_to_ipv4_prefix(
+        v4_row(**{"Local Preference": "0", "MED": "0", "Path ID": "0"})
+    )
+    assert prefix["local_preference"] == 0
+    assert prefix["multi_exit_discriminator"] == 0
+    assert "path_id" not in prefix
+
+
+def test_path_id_present_when_set(bgp):
+    prefix = bgp._row_to_ipv4_prefix(v4_row(**{"Path ID": "7"}))
+    assert prefix["path_id"] == 7
+
+
+@pytest.mark.parametrize(
+    "origin_cell, expected",
+    [
+        ("EGP", "egp"),
+        ("IGP", "igp"),
+        ("egp", "egp"),
+        ("Igp", "igp"),
+        ("INCOMPLETE", "incomplete"),
+        # Single-char forms are unused on 10.80 but still mapped.
+        ("i", "igp"),
+        ("e", "egp"),
+        ("?", "incomplete"),
+    ],
+)
+def test_origin_mapping(bgp, origin_cell, expected):
+    prefix = bgp._row_to_ipv4_prefix(v4_row(**{"Origin": origin_cell}))
+    assert prefix["origin"] == expected
+
+
+def test_unmapped_origin_is_omitted(bgp):
+    prefix = bgp._row_to_ipv4_prefix(v4_row(**{"Origin": "wat"}))
+    assert "origin" not in prefix
+
+
+# --- next-hop selection ----------------------------------------------------
+
+
+def test_next_hop_prefers_explicit_family_columns(bgp):
+    ipv4_nh, ipv6_nh = bgp._get_next_hops(
+        v4_row(**{"IPv4 Next Hop": "10.0.0.1", "IPv6 Next Hop": "2000::1"})
+    )
+    assert (ipv4_nh, ipv6_nh) == ("10.0.0.1", "2000::1")
+
+
+def test_next_hop_placeholders_yield_none_without_warning(bgp, caplog):
+    """Columns present but empty is a normal row, not a schema change."""
+    with caplog.at_level(logging.WARNING):
+        nh = bgp._get_next_hops(
+            v4_row(
+                **{"IPv4 Next Hop": "NA", "IPv6 Next Hop": "removePacket[ ]"}
+            )
+        )
+    assert nh == (None, None)
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("10.0.0.9", ("10.0.0.9", None)), ("2000::1", (None, "2000::1"))],
+)
+def test_next_hop_legacy_single_column_fallback(bgp, value, expected):
+    """The legacy 'Next Hop' column infers family from ':'."""
+    row = v4_row(
+        **{"IPv4 Next Hop": None, "IPv6 Next Hop": None, "Next Hop": value}
+    )
+    assert bgp._get_next_hops(row) == expected
+
+
+def test_missing_all_next_hop_columns_warns_once(bgp, caplog):
+    row = v4_row(**{"IPv4 Next Hop": None, "IPv6 Next Hop": None})
+    with caplog.at_level(logging.WARNING):
+        assert bgp._get_next_hops(row) == (None, None)
+        bgp._get_next_hops(row)
+        bgp._get_next_hops(row)
+    assert len(caplog.records) == 1, "warning should be deduplicated"
+    assert "Next Hop" in caplog.records[0].getMessage()
+
+
+# --- schema-drift warnings -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column", ["Prefix Length", "Origin", "AS Path", "Community", "MED"]
+)
+def test_renamed_column_warns(bgp, caplog, column):
+    """A vanished column must surface in the log, not silently drop data."""
+    with caplog.at_level(logging.WARNING):
+        bgp._row_to_ipv4_prefix(v4_row(**{column: None}))
+    assert any(
+        column in r.getMessage() for r in caplog.records
+    ), "no warning mentioning the missing %r column" % column
+
+
+def test_column_warning_is_deduplicated_across_rows(bgp, caplog):
+    rows = [v4_row(**{"MED": None}) for _ in range(5)]
+    bgp._warned_columns = set()
+    with caplog.at_level(logging.WARNING):
+        for row in rows:
+            bgp._row_to_ipv4_prefix(row)
+    med_warnings = [
+        r for r in caplog.records if "MED" in r.getMessage()
+    ]
+    assert len(med_warnings) == 1, "one warning per column, not per row"
+
+
+def test_trailing_space_in_column_name_is_tolerated(bgp):
+    """'IPv4 Prefix ' (with the real trailing space) must still match."""
+    row = make_row(["IPv4 Prefix ", "Prefix Length"], ["1.1.1.0", "24"])
+    assert bgp._row_to_ipv4_prefix(row)["ipv4_address"] == "1.1.1.0"
+
+
+# ---------------------------------------------------------------------------
+# Filters: _prefix_matches_filter / _apply_v4_filters / _apply_v6_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def v4_prefixes(bgp):
+    return [
+        bgp._row_to_ipv4_prefix(
+            v4_row(
+                **{
+                    "IPv4 Prefix": "100.1.%d.0" % n,
+                    "Path ID": str(n) if n else "NA",
+                }
+            )
+        )
+        for n in range(3)
+    ]
+
+
+def addresses_of(prefixes):
+    return [p["ipv4_address"] for p in prefixes]
+
+
+def test_no_filters_returns_everything(bgp, v4_prefixes):
+    assert bgp._apply_v4_filters(v4_prefixes, None) == v4_prefixes
+    assert bgp._apply_v4_filters(v4_prefixes, []) == v4_prefixes
+
+
+def test_filter_by_address(bgp, v4_prefixes):
+    filt = make_filter(addresses=["100.1.1.0"])
+    result = bgp._apply_v4_filters(v4_prefixes, [filt])
+    assert addresses_of(result) == ["100.1.1.0"]
+
+
+def test_filter_by_multiple_addresses(bgp, v4_prefixes):
+    filt = make_filter(addresses=["100.1.0.0", "100.1.2.0"])
+    result = bgp._apply_v4_filters(v4_prefixes, [filt])
+    assert addresses_of(result) == ["100.1.0.0", "100.1.2.0"]
+
+
+def test_filter_fields_are_anded(bgp, v4_prefixes):
+    """Within one filter every set field must match."""
+    matching = make_filter(addresses=["100.1.1.0"], prefix_length=24)
+    assert len(bgp._apply_v4_filters(v4_prefixes, [matching])) == 1
+
+    conflicting = make_filter(addresses=["100.1.1.0"], prefix_length=25)
+    assert bgp._apply_v4_filters(v4_prefixes, [conflicting]) == []
+
+
+def test_multiple_filters_are_ored(bgp, v4_prefixes):
+    filters = [
+        make_filter(addresses=["100.1.0.0"]),
+        make_filter(addresses=["100.1.2.0"]),
+    ]
+    result = bgp._apply_v4_filters(v4_prefixes, filters)
+    assert addresses_of(result) == ["100.1.0.0", "100.1.2.0"]
+
+
+def test_unset_filter_fields_are_wildcards(bgp, v4_prefixes):
+    assert bgp._apply_v4_filters(v4_prefixes, [make_filter()]) == v4_prefixes
+
+
+def test_filter_by_origin(bgp, v4_prefixes):
+    matching = bgp._apply_v4_filters(
+        v4_prefixes, [make_filter(origin="egp")]
+    )
+    assert len(matching) == 3
+    assert bgp._apply_v4_filters(
+        v4_prefixes, [make_filter(origin="igp")]
+    ) == []
+
+
+def test_filter_by_path_id(bgp, v4_prefixes):
+    result = bgp._apply_v4_filters(v4_prefixes, [make_filter(path_id=2)])
+    assert addresses_of(result) == ["100.1.2.0"]
+
+
+def test_filter_path_id_zero_matches_absent_path_id(bgp, v4_prefixes):
+    """A prefix with no path_id is treated as path_id 0.
+
+    Documents the current default; the OTG spec is worth re-checking here
+    (tracked as X5 in the review notes).
+    """
+    result = bgp._apply_v4_filters(v4_prefixes, [make_filter(path_id=0)])
+    assert addresses_of(result) == ["100.1.0.0"]
+
+
+def test_v6_filters_use_the_ipv6_address_key(bgp):
+    prefixes = [
+        bgp._row_to_ipv6_prefix(v6_row(**{"IPv6 Prefix": "4000::"})),
+        bgp._row_to_ipv6_prefix(v6_row(**{"IPv6 Prefix": "5000::"})),
+    ]
+    filt = make_filter(family="ipv6", addresses=["5000::"])
+    result = bgp._apply_v6_filters(prefixes, [filt])
+    assert [p["ipv6_address"] for p in result] == ["5000::"]
+
+
+# ---------------------------------------------------------------------------
+# The parsers' output must survive the real OTG model
+# ---------------------------------------------------------------------------
+
+
+def test_parsed_prefixes_deserialize_into_states_response(bgp):
+    """Mirror snappi_api.get_states: deserialize the dict we hand back.
+
+    This is the check that catches a parser emitting a model-invalid value
+    (an out-of-range community, say) -- which in the real API surfaces as
+    an opaque TypeError from serialize(), not as a parsing error.
+    """
+    v4 = bgp._row_to_ipv4_prefix(v4_row(**{"Path ID": "7"}))
+    v6 = bgp._row_to_ipv6_prefix(v6_row())
+    response = snappi.StatesResponse()
+    response.deserialize(
+        {
+            "choice": "bgp_prefixes",
+            "bgp_prefixes": [
+                {
+                    "bgp_peer_name": "bgpv4_peer2",
+                    "ipv4_unicast_prefixes": [v4],
+                    "ipv6_unicast_prefixes": [v6],
+                }
+            ],
+        }
+    )
+    # serialize() is where snappi enforces formats and ranges.
+    response.serialize()
+
+    state = response.bgp_prefixes[0]
+    got_v4 = state.ipv4_unicast_prefixes[0]
+    assert got_v4.ipv4_address == "100.1.0.0"
+    assert got_v4.prefix_length == 24
+    assert got_v4.origin == "egp"
+    assert got_v4.multi_exit_discriminator == 50
+    assert got_v4.path_id == 7
+    assert got_v4.as_path.segments[0].type == "as_seq"
+    assert got_v4.as_path.segments[0].as_numbers == [100, 200]
+    assert got_v4.communities[0].as_number == 1
+    assert got_v4.communities[0].as_custom == 2
+
+    got_v6 = state.ipv6_unicast_prefixes[0]
+    assert got_v6.ipv6_address == "4000::"
+    assert got_v6.ipv6_next_hop == "2000::1"
+    assert got_v6.as_path.segments[0].as_numbers == [500, 600]
+
+
+@pytest.mark.parametrize(
+    "as_path_cell, community_cell",
+    [
+        ("{100 200} 300", "1:2 3:4"),
+        ("(65001) [65002] <4200000000>", "no-export 65535:65535"),
+        ("", ""),
+    ],
+)
+def test_varied_attributes_survive_the_model(
+    bgp, as_path_cell, community_cell
+):
+    prefix = bgp._row_to_ipv4_prefix(
+        v4_row(**{"AS Path": as_path_cell, "Community": community_cell})
+    )
+    response = snappi.StatesResponse()
+    response.deserialize(
+        {
+            "choice": "bgp_prefixes",
+            "bgp_prefixes": [
+                {
+                    "bgp_peer_name": "p",
+                    "ipv4_unicast_prefixes": [prefix],
+                }
+            ],
+        }
+    )
+    response.serialize()

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -19,6 +19,15 @@ Route ranges
   rr2  200.1.0.0/24 x 5   AS-path [300,400]  comm 3:4  MED 60  origin egp
   rr1v6  4000::/64 x 5    AS-path [500,600]  origin igp
   rr2v6  5000::/64 x 5    AS-path [700,800]  origin igp
+
+  rr3  100.1.0.0/24 x 5   (eBGP / 4-byte AS config only)
+                          AS-path as_seq [100,200] + as_set [300,400]
+                                  + as_seq [4200000000]
+                          comm 1:2, 65535:65535, no_export
+                          MED 70  origin incomplete
+
+The parsing logic these tests exercise end-to-end is also covered offline,
+without a chassis, in test_bgp_prefix_parsers.py.
 """
 import pytest
 
@@ -93,6 +102,112 @@ def _build_v4_config(api, b2b_raw_config):
     return b2b_raw_config
 
 
+def _build_rich_attrs_config(api, b2b_raw_config):
+    """Return b2b_raw_config wired for **eBGP with 4-byte AS numbers** and a
+    route range carrying several AS-path segments and several communities.
+
+    Deliberately different from _build_v4_config on every axis the parsers
+    have to handle:
+
+    ==================  ====================  =========================
+    axis                _build_v4_config      here
+    ==================  ====================  =========================
+    session type        iBGP, AS 65001        eBGP, AS 4200000001/2
+    as_number_width     default ("four")      explicit "four", 4-byte AS
+    AS-path segments    1 (as_seq)            3 (as_seq, as_set, as_seq)
+    communities         1 (manual)            3 (2 manual + no_export)
+    origin              egp                   incomplete
+    ==================  ====================  =========================
+
+    ``as_set_mode`` is left at its OTG default (``do_not_include_local_as``)
+    so the learned AS path is exactly what is configured -- the local AS is
+    not prepended, which keeps the assertions deterministic.
+    """
+    api.set_config(api.config())
+    b2b_raw_config.flows.clear()
+
+    p1, p2 = b2b_raw_config.ports
+    d1, d2 = (
+        b2b_raw_config.devices.device(name="tx_dev")
+        .device(name="rx_dev")
+    )
+
+    eth1, eth2 = d1.ethernets.add(), d2.ethernets.add()
+    eth1.connection.port_name = p1.name
+    eth2.connection.port_name = p2.name
+    eth1.mac, eth2.mac = "00:00:00:00:00:11", "00:00:00:00:00:22"
+    eth1.name, eth2.name = "eth1", "eth2"
+
+    ip1, ip2 = eth1.ipv4_addresses.add(), eth2.ipv4_addresses.add()
+    ip1.name, ip2.name = "ipv4_1", "ipv4_2"
+    ip1.address, ip1.gateway, ip1.prefix = "10.1.1.1", "10.1.1.2", 24
+    ip2.address, ip2.gateway, ip2.prefix = "10.1.1.2", "10.1.1.1", 24
+
+    bgp1, bgp2 = d1.bgp, d2.bgp
+    bgp1.router_id, bgp2.router_id = "192.0.0.1", "192.0.0.2"
+
+    i1, i2 = bgp1.ipv4_interfaces.add(), bgp2.ipv4_interfaces.add()
+    i1.ipv4_name, i2.ipv4_name = ip1.name, ip2.name
+
+    peer1, peer2 = i1.peers.add(), i2.peers.add()
+    peer1.name, peer2.name = "bgpv4_peer1", "bgpv4_peer2"
+    # eBGP with 4-byte AS numbers on both sides.  as_number_width is set
+    # explicitly even though "four" is already the OTG default, so the test
+    # keeps testing 4-byte encoding if that default ever changes.
+    peer1.peer_address, peer1.as_type = "10.1.1.2", "ebgp"
+    peer2.peer_address, peer2.as_type = "10.1.1.1", "ebgp"
+    peer1.as_number, peer2.as_number = 4200000001, 4200000002
+    peer1.as_number_width = peer2.as_number_width = "four"
+    peer1.learned_information_filter.unicast_ipv4_prefix = True
+    peer2.learned_information_filter.unicast_ipv4_prefix = True
+
+    # rr3: advertised by peer1, learned by peer2.
+    rr3 = peer1.v4_routes.add(name="rr3")
+    rr3.addresses.add(address="100.1.0.0", prefix=24, count=5, step=1)
+
+    seg_a = rr3.as_path.segments.add()
+    seg_a.type = seg_a.AS_SEQ
+    seg_a.as_numbers = [100, 200]
+    seg_b = rr3.as_path.segments.add()
+    seg_b.type = seg_b.AS_SET
+    seg_b.as_numbers = [300, 400]
+    # A 4-byte ASN inside the path, to prove asplain 4-byte values survive
+    # the round trip through the learned-info AS Path column.
+    seg_c = rr3.as_path.segments.add()
+    seg_c.type = seg_c.AS_SEQ
+    seg_c.as_numbers = [4200000000]
+
+    c1 = rr3.communities.add()
+    c1.type = c1.MANUAL_AS_NUMBER
+    c1.as_number, c1.as_custom = 1, 2
+    c2 = rr3.communities.add()
+    c2.type = c2.MANUAL_AS_NUMBER
+    c2.as_number, c2.as_custom = 65535, 65535
+    c3 = rr3.communities.add()
+    c3.type = c3.NO_EXPORT
+
+    rr3.advanced.multi_exit_discriminator = 70
+    rr3.advanced.origin = rr3.advanced.INCOMPLETE
+
+    return b2b_raw_config
+
+
+def _build_two_byte_as_config(api, b2b_raw_config):
+    """Return b2b_raw_config using ``as_number_width = "two"``.
+
+    2-byte AS numbers take a different branch in ``Bgp._config_as_number``
+    (``localAs2Bytes`` rather than ``enable4ByteAs`` + ``localAs4Bytes``),
+    and the default is "four", so this path is otherwise untested.
+    """
+    config = _build_v4_config(api, b2b_raw_config)
+    for device in config.devices:
+        for interface in device.bgp.ipv4_interfaces:
+            for peer in interface.peers:
+                peer.as_number_width = "two"
+                peer.as_number = 65001
+    return config
+
+
 def _build_dual_stack_config(api, b2b_raw_config):
     """Return b2b_raw_config with both IPv4 and IPv6 BGP peers and routes."""
     config = _build_v4_config(api, b2b_raw_config)
@@ -142,6 +257,21 @@ def _build_dual_stack_config(api, b2b_raw_config):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _segments_of(prefix):
+    """Flatten a learned prefix's AS path to ``[(type, [asn, ...]), ...]``."""
+    return [(s.type, list(s.as_numbers)) for s in prefix.as_path.segments]
+
+
+def _communities_of(prefix):
+    """Flatten a learned prefix's communities to comparable tuples.
+
+    ``as_number``/``as_custom`` are ``None`` for well-known communities.
+    """
+    return [
+        (c.type, c.as_number, c.as_custom) for c in prefix.communities
+    ]
+
 
 def _bgpv4_routes_exchanged(api, expected_rx=1):
     """Return True once at least *expected_rx* routes have been received
@@ -233,8 +363,21 @@ def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
     assert segs[0].type == "as_seq"
     assert segs[0].as_numbers == [100, 200]
 
-    # At least one community with as_number=1
-    assert any(c.as_number == 1 for c in p.communities)
+    # Assert the whole community list, not just that a match exists -- a
+    # spurious extra entry or a mis-parsed as_custom would pass an any().
+    assert _communities_of(p) == [("manual_as_number", 1, 2)]
+
+    # Every prefix in the range must carry the same attributes, and the
+    # addresses must be the five distinct /24s that were advertised.
+    assert sorted(x.ipv4_address for x in prefixes) == [
+        "100.1.%d.0" % n for n in range(5)
+    ]
+    for other in prefixes:
+        assert other.prefix_length == 24
+        assert other.origin == "egp"
+        assert other.multi_exit_discriminator == 50
+        assert _segments_of(other) == [("as_seq", [100, 200])]
+        assert _communities_of(other) == [("manual_as_number", 1, 2)]
 
 
 def test_bgp_prefix_states_all_peers_b2b(api, b2b_raw_config, utils):
@@ -302,6 +445,103 @@ def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
     assert len(segs) == 1
     assert segs[0].type == "as_seq"
     assert segs[0].as_numbers == [500, 600]
+
+
+def test_bgp_prefix_states_multi_segment_multi_community_b2b(
+    api, b2b_raw_config, utils
+):
+    """
+    eBGP with 4-byte AS numbers, three AS-path segments and three
+    communities must all survive the learned-info round trip.
+
+    This is the counterpart to the offline parser tests in
+    test_bgp_prefix_parsers.py: those prove the parsers handle the shapes,
+    this proves IxNetwork actually emits them.
+
+    bgpv4_peer2 learns rr3 (100.1.0.0/24 x 5) advertised by bgpv4_peer1:
+      AS path      as_seq [100,200] + as_set [300,400] + as_seq [4200000000]
+      communities  1:2, 65535:65535, no_export
+      MED 70, origin incomplete
+    """
+    config = _build_rich_attrs_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 eBGP sessions to come up",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    states = api.get_states(req)
+
+    prefixes = states.bgp_prefixes[0].ipv4_unicast_prefixes
+    assert len(prefixes) == 5
+
+    for p in prefixes:
+        assert p.prefix_length == 24
+        assert p.origin == "incomplete"
+        assert p.multi_exit_discriminator == 70
+        # Segment order and type must be preserved, and the 4-byte ASN must
+        # come back as its asplain value rather than being dropped.
+        #
+        # The leading [4200000001] is bgpv4_peer1's own AS: over eBGP the
+        # advertising speaker prepends it as a separate AS_SEQ segment.
+        # That is standard BGP and happens regardless of the route's
+        # as_set_mode (which only controls whether the local AS is folded
+        # into the *configured* segments), so it is asserted rather than
+        # worked around.
+        assert _segments_of(p) == [
+            ("as_seq", [4200000001]),
+            ("as_seq", [100, 200]),
+            ("as_set", [300, 400]),
+            ("as_seq", [4200000000]),
+        ]
+        # Both manual communities plus the well-known NO_EXPORT.  Compared
+        # as a set because the learned-info column order is not contractual.
+        assert set(_communities_of(p)) == {
+            ("manual_as_number", 1, 2),
+            ("manual_as_number", 65535, 65535),
+            ("no_export", None, None),
+        }
+
+
+def test_bgp_prefix_states_two_byte_as_b2b(api, b2b_raw_config, utils):
+    """
+    ``as_number_width = "two"`` must not change the learned-prefix result.
+
+    The 2-byte branch of Bgp._config_as_number (``localAs2Bytes``) is
+    otherwise untested, since "four" is the OTG default.
+    """
+    config = _build_two_byte_as_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 sessions to come up with 2-byte AS",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    states = api.get_states(req)
+
+    prefixes = states.bgp_prefixes[0].ipv4_unicast_prefixes
+    assert len(prefixes) == 5
+    for p in prefixes:
+        assert _segments_of(p) == [("as_seq", [100, 200])]
+        assert _communities_of(p) == [("manual_as_number", 1, 2)]
+        assert p.origin == "egp"
+        assert p.multi_exit_discriminator == 50
 
 
 def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -321,7 +321,7 @@ def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
     """
     Verify IPv4 unicast learned-prefix state is returned per BGP peer.
 
-    bgpv4_peer2 should learn rr1 (100.1.0.0/24 × 5) with AS-path [100,200],
+    bgpv4_peer2 should learn rr1 (100.1.0.0/24 x 5) with AS-path [100,200],
     community 1:2, MED 50 and origin EGP from bgpv4_peer1.
     """
     config = _build_v4_config(api, b2b_raw_config)
@@ -414,7 +414,7 @@ def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
     Verify IPv6 unicast learned-prefix state is returned for BGPv6 peers
     in a dual-stack configuration.
 
-    bgpv6_peer2 should learn rr1v6 (4000::/64 × 5) with AS-path [500,600]
+    bgpv6_peer2 should learn rr1v6 (4000::/64 x 5) with AS-path [500,600]
     and origin IGP from bgpv6_peer1.
     """
     config = _build_dual_stack_config(api, b2b_raw_config)
@@ -549,7 +549,7 @@ def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):
     ipv4_unicast_filters must narrow the result to matching prefixes only.
 
     A filter for address 100.1.0.0 / prefix_length 24 applied to
-    bgpv4_peer2 (which learns 5 prefixes: 100.1.0.0–100.1.4.0 /24)
+    bgpv4_peer2 (which learns 5 prefixes: 100.1.0.0-100.1.4.0 /24)
     should return exactly 1 matching prefix.
     """
     config = _build_v4_config(api, b2b_raw_config)

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -1,0 +1,350 @@
+"""
+B2B tests for get_states(bgp_prefixes) — IxNetwork backend implementation
+of OTG learned-prefix state (AS-path, next-hop, origin, MED, communities).
+
+Topology (all tests)
+--------------------
+  Port tx ──── Port rx
+  Device tx_dev          Device rx_dev
+    eth1 (00:00:00:11)     eth2 (00:00:00:22)
+    ipv4_1 10.1.1.1/24 ←→  ipv4_2 10.1.1.2/24
+    [ipv6_1 2001:db8::1/64 ← → ipv6_2 2001:db8::2/64  (dual-stack tests)]
+
+  bgpv4_peer1 ←iBGP→ bgpv4_peer2  (AS 65001)
+  [bgpv6_peer1 ←iBGP→ bgpv6_peer2  (dual-stack tests)]
+
+Route ranges
+------------
+  rr1  100.1.0.0/24 x 5   AS-path [100,200]  comm 1:2  MED 50  origin egp
+  rr2  200.1.0.0/24 x 5   AS-path [300,400]  comm 3:4  MED 60  origin egp
+  rr1v6  4000::/64 x 5    AS-path [500,600]  origin igp
+  rr2v6  5000::/64 x 5    AS-path [700,800]  origin igp
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared config builders
+# ---------------------------------------------------------------------------
+
+def _build_v4_config(api, b2b_raw_config):
+    """Return b2b_raw_config wired for two iBGP peers with IPv4 route ranges
+    that carry AS-path, community, MED and origin attributes."""
+    api.set_config(api.config())
+    b2b_raw_config.flows.clear()
+
+    p1, p2 = b2b_raw_config.ports
+    d1, d2 = (
+        b2b_raw_config.devices.device(name="tx_dev")
+        .device(name="rx_dev")
+    )
+
+    eth1, eth2 = d1.ethernets.add(), d2.ethernets.add()
+    eth1.connection.port_name = p1.name
+    eth2.connection.port_name = p2.name
+    eth1.mac, eth2.mac = "00:00:00:00:00:11", "00:00:00:00:00:22"
+    eth1.name, eth2.name = "eth1", "eth2"
+
+    ip1, ip2 = eth1.ipv4_addresses.add(), eth2.ipv4_addresses.add()
+    ip1.name, ip2.name = "ipv4_1", "ipv4_2"
+    ip1.address, ip1.gateway, ip1.prefix = "10.1.1.1", "10.1.1.2", 24
+    ip2.address, ip2.gateway, ip2.prefix = "10.1.1.2", "10.1.1.1", 24
+
+    bgp1, bgp2 = d1.bgp, d2.bgp
+    bgp1.router_id, bgp2.router_id = "192.0.0.1", "192.0.0.2"
+
+    i1, i2 = bgp1.ipv4_interfaces.add(), bgp2.ipv4_interfaces.add()
+    i1.ipv4_name, i2.ipv4_name = ip1.name, ip2.name
+
+    peer1, peer2 = i1.peers.add(), i2.peers.add()
+    peer1.name, peer2.name = "bgpv4_peer1", "bgpv4_peer2"
+    peer1.peer_address, peer1.as_type, peer1.as_number = "10.1.1.2", "ibgp", 65001
+    peer2.peer_address, peer2.as_type, peer2.as_number = "10.1.1.1", "ibgp", 65001
+    # Enable IxNetwork to capture IPv4 unicast routes in learnedInfo.
+    # Without this flag the FilterIpV4Unicast Multivalue stays False and
+    # GetIPv4LearnedInfo returns no data.
+    peer1.learned_information_filter.unicast_ipv4_prefix = True
+    peer2.learned_information_filter.unicast_ipv4_prefix = True
+
+    # rr1: advertised by peer1, learned by peer2
+    rr1 = peer1.v4_routes.add(name="rr1")
+    rr1.addresses.add(address="100.1.0.0", prefix=24, count=5, step=1)
+    seg1 = rr1.as_path.segments.add()
+    seg1.type = seg1.AS_SEQ
+    seg1.as_numbers = [100, 200]
+    c1 = rr1.communities.add()
+    c1.type = c1.MANUAL_AS_NUMBER
+    c1.as_number, c1.as_custom = 1, 2
+    rr1.advanced.multi_exit_discriminator = 50
+    rr1.advanced.origin = rr1.advanced.EGP
+
+    # rr2: advertised by peer2, learned by peer1
+    rr2 = peer2.v4_routes.add(name="rr2")
+    rr2.addresses.add(address="200.1.0.0", prefix=24, count=5, step=1)
+    seg2 = rr2.as_path.segments.add()
+    seg2.type = seg2.AS_SEQ
+    seg2.as_numbers = [300, 400]
+    c2 = rr2.communities.add()
+    c2.type = c2.MANUAL_AS_NUMBER
+    c2.as_number, c2.as_custom = 3, 4
+    rr2.advanced.multi_exit_discriminator = 60
+    rr2.advanced.origin = rr2.advanced.EGP
+
+    return b2b_raw_config
+
+
+def _build_dual_stack_config(api, b2b_raw_config):
+    """Return b2b_raw_config with both IPv4 and IPv6 BGP peers and routes."""
+    config = _build_v4_config(api, b2b_raw_config)
+
+    d1, d2 = [d for d in config.devices]
+
+    eth1 = d1.ethernets[0]
+    eth2 = d2.ethernets[0]
+
+    ip6_1, ip6_2 = eth1.ipv6_addresses.add(), eth2.ipv6_addresses.add()
+    ip6_1.name, ip6_2.name = "ipv6_1", "ipv6_2"
+    ip6_1.address, ip6_1.gateway, ip6_1.prefix = "2001:db8::1", "2001:db8::2", 64
+    ip6_2.address, ip6_2.gateway, ip6_2.prefix = "2001:db8::2", "2001:db8::1", 64
+
+    bgp1, bgp2 = d1.bgp, d2.bgp
+
+    i6_1, i6_2 = bgp1.ipv6_interfaces.add(), bgp2.ipv6_interfaces.add()
+    i6_1.ipv6_name, i6_2.ipv6_name = ip6_1.name, ip6_2.name
+
+    p6_1, p6_2 = i6_1.peers.add(), i6_2.peers.add()
+    p6_1.name, p6_2.name = "bgpv6_peer1", "bgpv6_peer2"
+    p6_1.peer_address, p6_1.as_type, p6_1.as_number = "2001:db8::2", "ibgp", 65001
+    p6_2.peer_address, p6_2.as_type, p6_2.as_number = "2001:db8::1", "ibgp", 65001
+    # Enable IxNetwork to capture IPv6 unicast routes in learnedInfo.
+    p6_1.learned_information_filter.unicast_ipv6_prefix = True
+    p6_2.learned_information_filter.unicast_ipv6_prefix = True
+
+    # rr1v6: advertised by bgpv6_peer1, learned by bgpv6_peer2
+    rr1v6 = p6_1.v6_routes.add(name="rr1v6")
+    rr1v6.addresses.add(address="4000::", prefix=64, count=5, step=1)
+    seg6_1 = rr1v6.as_path.segments.add()
+    seg6_1.type = seg6_1.AS_SEQ
+    seg6_1.as_numbers = [500, 600]
+    rr1v6.advanced.origin = rr1v6.advanced.IGP
+
+    # rr2v6: advertised by bgpv6_peer2, learned by bgpv6_peer1
+    rr2v6 = p6_2.v6_routes.add(name="rr2v6")
+    rr2v6.addresses.add(address="5000::", prefix=64, count=5, step=1)
+    seg6_2 = rr2v6.as_path.segments.add()
+    seg6_2.type = seg6_2.AS_SEQ
+    seg6_2.as_numbers = [700, 800]
+    rr2v6.advanced.origin = rr2v6.advanced.IGP
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bgpv4_routes_exchanged(api, expected_rx=1):
+    """Return True once at least *expected_rx* routes have been received
+    across all BGPv4 sessions.  Ensures route UPDATEs have completed
+    before querying learned-info."""
+    req = api.metrics_request()
+    req.bgpv4.column_names = ["session_state", "routes_received"]
+    results = api.get_metrics(req)
+    total_rx = sum(
+        (m.routes_received or 0) for m in results.bgpv4_metrics
+    )
+    return total_rx >= expected_rx
+
+
+def _bgpv4_sessions_up(api, expected_count=2):
+    """Return True once exactly *expected_count* BGPv4 sessions report 'up'.
+
+    Uses an empty peer_names list so that protocolmetrics returns all
+    BGPv4 device-group rows.  Passing peer *names* (not device names)
+    would cause the Device-Group filter inside protocolmetrics to drop
+    every row, leaving an empty result regardless of session state.
+    """
+    req = api.metrics_request()
+    req.bgpv4.column_names = ["session_state"]
+    results = api.get_metrics(req)
+    return (
+        len(results.bgpv4_metrics) == expected_count
+        and all(m.session_state == "up" for m in results.bgpv4_metrics)
+    )
+
+
+def _bgpv6_sessions_up(api, expected_count=2):
+    """Return True once exactly *expected_count* BGPv6 sessions report 'up'."""
+    req = api.metrics_request()
+    req.bgpv6.column_names = ["session_state"]
+    results = api.get_metrics(req)
+    return (
+        len(results.bgpv6_metrics) == expected_count
+        and all(m.session_state == "up" for m in results.bgpv6_metrics)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
+def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
+    """
+    Verify IPv4 unicast learned-prefix state is returned per BGP peer.
+
+    bgpv4_peer2 should learn rr1 (100.1.0.0/24 × 5) with AS-path [100,200],
+    community 1:2, MED 50 and origin EGP from bgpv4_peer1.
+    """
+    config = _build_v4_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 sessions to come up",
+        timeout_seconds=30,
+    )
+    # Allow a moment for route UPDATEs to be fully exchanged before
+    # querying learned info.
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    states = api.get_states(req)
+
+    print("states: {}".format(states))
+    assert len(states.bgp_prefixes) == 1
+    peer_state = states.bgp_prefixes[0]
+    assert peer_state.bgp_peer_name == "bgpv4_peer2"
+    print("peer_state: {}".format(peer_state))
+
+    prefixes = peer_state.ipv4_unicast_prefixes
+    assert len(prefixes) == 5
+
+    # Spot-check the first returned prefix
+    p = prefixes[0]
+    assert p.ipv4_address.startswith("100.1.0.")
+    assert p.prefix_length == 24
+    assert p.origin == "egp"
+    assert p.multi_exit_discriminator == 50
+
+    # AS-path must carry exactly one AS_SEQ segment [100, 200]
+    segs = p.as_path.segments
+    assert len(segs) == 1
+    assert segs[0].type == "as_seq"
+    assert segs[0].as_numbers == [100, 200]
+
+    # At least one community with as_number=1
+    assert any(c.as_number == 1 for c in p.communities)
+
+
+@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
+def test_bgp_prefix_states_all_peers_b2b(api, b2b_raw_config, utils):
+    """
+    Empty bgp_peer_names must return learned-prefix state for every
+    configured peer.
+    """
+    config = _build_v4_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 sessions to come up",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    req = api.states_request()
+    # Leave bgp_peer_names empty → should return both peers
+    states = api.get_states(req)
+
+    peer_names_returned = {s.bgp_peer_name for s in states.bgp_prefixes}
+    assert "bgpv4_peer1" in peer_names_returned
+    assert "bgpv4_peer2" in peer_names_returned
+    assert len(states.bgp_prefixes) == 2
+
+
+@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
+def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
+    """
+    Verify IPv6 unicast learned-prefix state is returned for BGPv6 peers
+    in a dual-stack configuration.
+
+    bgpv6_peer2 should learn rr1v6 (4000::/64 × 5) with AS-path [500,600]
+    and origin IGP from bgpv6_peer1.
+    """
+    config = _build_dual_stack_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv6_sessions_up(api),
+        "BGPv6 sessions to come up",
+        timeout_seconds=30,
+    )
+
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv6_peer2"]
+    states = api.get_states(req)
+
+    assert len(states.bgp_prefixes) == 1
+    peer_state = states.bgp_prefixes[0]
+    assert peer_state.bgp_peer_name == "bgpv6_peer2"
+
+    prefixes = peer_state.ipv6_unicast_prefixes
+    assert len(prefixes) == 5
+
+    p = prefixes[0]
+    assert p.ipv6_address.lower().startswith("4000:")
+    assert p.prefix_length == 64
+    assert p.origin == "igp"
+
+    segs = p.as_path.segments
+    assert len(segs) == 1
+    assert segs[0].type == "as_seq"
+    assert segs[0].as_numbers == [500, 600]
+
+
+@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
+def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):
+    """
+    ipv4_unicast_filters must narrow the result to matching prefixes only.
+
+    A filter for address 100.1.0.0 / prefix_length 24 applied to
+    bgpv4_peer2 (which learns 5 prefixes: 100.1.0.0–100.1.4.0 /24)
+    should return exactly 1 matching prefix.
+    """
+    config = _build_v4_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 sessions to come up",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    # Unfiltered: expect 5 prefixes
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    unfiltered = api.get_states(req)
+    assert len(unfiltered.bgp_prefixes[0].ipv4_unicast_prefixes) == 5
+
+    # Filtered: only 100.1.0.0/24
+    req2 = api.states_request()
+    req2.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    filt = req2.bgp_prefixes.ipv4_unicast_filters.add()
+    filt.addresses = ["100.1.0.0"]
+    filt.prefix_length = 24
+    filtered = api.get_states(req2)
+
+    filtered_prefixes = filtered.bgp_prefixes[0].ipv4_unicast_prefixes
+    assert len(filtered_prefixes) == 1
+    assert filtered_prefixes[0].ipv4_address == "100.1.0.0"
+    assert filtered_prefixes[0].prefix_length == 24

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -583,3 +583,84 @@ def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):
     assert len(filtered_prefixes) == 1
     assert filtered_prefixes[0].ipv4_address == "100.1.0.0"
     assert filtered_prefixes[0].prefix_length == 24
+
+
+def test_bgp_prefix_states_prefix_filters_b2b(api, b2b_raw_config, utils):
+    """
+    prefix_filters must select which address families are reported.
+
+    Distinct from ipv4/ipv6_unicast_filters, which narrow the prefixes
+    *within* a family.  Run on the dual-stack config so both families are
+    genuinely available to choose between.
+    """
+    config = _build_dual_stack_config(api, b2b_raw_config)
+    utils.start_traffic(api, config, start_capture=False)
+    utils.wait_for(
+        lambda: _bgpv4_sessions_up(api),
+        "BGPv4 sessions to come up",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv6_sessions_up(api),
+        "BGPv6 sessions to come up",
+        timeout_seconds=30,
+    )
+    utils.wait_for(
+        lambda: _bgpv4_routes_exchanged(api, expected_rx=5),
+        "BGPv4 routes to be received",
+        timeout_seconds=30,
+    )
+
+    # No prefix_filters: every supported family is reported.
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2", "bgpv6_peer2"]
+    states = api.get_states(req)
+
+    by_name = {s.bgp_peer_name: s for s in states.bgp_prefixes}
+    assert sorted(by_name) == ["bgpv4_peer2", "bgpv6_peer2"]
+    # One entry per peer, never one per family.
+    assert len(states.bgp_prefixes) == 2
+    assert len(by_name["bgpv4_peer2"].ipv4_unicast_prefixes) == 5
+    assert len(by_name["bgpv6_peer2"].ipv6_unicast_prefixes) == 5
+
+    # ipv4_unicast only: the IPv6 peer reports no prefixes at all.
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2", "bgpv6_peer2"]
+    req.bgp_prefixes.prefix_filters = ["ipv4_unicast"]
+    states = api.get_states(req)
+
+    by_name = {s.bgp_peer_name: s for s in states.bgp_prefixes}
+    assert len(by_name["bgpv4_peer2"].ipv4_unicast_prefixes) == 5
+    assert len(by_name["bgpv6_peer2"].ipv6_unicast_prefixes) == 0
+    assert len(by_name["bgpv6_peer2"].ipv4_unicast_prefixes) == 0
+
+    # ipv6_unicast only: the mirror image.
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2", "bgpv6_peer2"]
+    req.bgp_prefixes.prefix_filters = ["ipv6_unicast"]
+    states = api.get_states(req)
+
+    by_name = {s.bgp_peer_name: s for s in states.bgp_prefixes}
+    assert len(by_name["bgpv6_peer2"].ipv6_unicast_prefixes) == 5
+    assert len(by_name["bgpv4_peer2"].ipv4_unicast_prefixes) == 0
+
+    # prefix_filters composes with the per-family prefix filters.
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    req.bgp_prefixes.prefix_filters = ["ipv4_unicast"]
+    filt = req.bgp_prefixes.ipv4_unicast_filters.add()
+    filt.addresses = ["100.1.2.0"]
+    states = api.get_states(req)
+
+    prefixes = states.bgp_prefixes[0].ipv4_unicast_prefixes
+    assert len(prefixes) == 1
+    assert prefixes[0].ipv4_address == "100.1.2.0"
+
+    # An address family the backend cannot retrieve must fail loudly rather
+    # than return an empty result that looks like "nothing was learned".
+    req = api.states_request()
+    req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
+    req.bgp_prefixes.prefix_filters = ["ipv4_mpls_unicast"]
+    with pytest.raises(Exception) as excinfo:
+        api.get_states(req)
+    assert "not supported" in str(excinfo.value)

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -266,7 +266,6 @@ def test_bgp_prefix_states_all_peers_b2b(api, b2b_raw_config, utils):
     assert len(states.bgp_prefixes) == 2
 
 
-@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
 def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
     """
     Verify IPv6 unicast learned-prefix state is returned for BGPv6 peers
@@ -305,7 +304,7 @@ def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
     assert segs[0].as_numbers == [500, 600]
 
 
-@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
+# @pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
 def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):
     """
     ipv4_unicast_filters must narrow the result to matching prefixes only.

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -304,7 +304,6 @@ def test_bgp_prefix_states_ipv6_b2b(api, b2b_raw_config, utils):
     assert segs[0].as_numbers == [500, 600]
 
 
-# @pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
 def test_bgp_prefix_states_filter_b2b(api, b2b_raw_config, utils):
     """
     ipv4_unicast_filters must narrow the result to matching prefixes only.

--- a/tests/bgp/test_bgp_prefix_states.py
+++ b/tests/bgp/test_bgp_prefix_states.py
@@ -187,7 +187,6 @@ def _bgpv6_sessions_up(api, expected_count=2):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
 def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
     """
     Verify IPv4 unicast learned-prefix state is returned per BGP peer.
@@ -214,11 +213,9 @@ def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
     req.bgp_prefixes.bgp_peer_names = ["bgpv4_peer2"]
     states = api.get_states(req)
 
-    print("states: {}".format(states))
     assert len(states.bgp_prefixes) == 1
     peer_state = states.bgp_prefixes[0]
     assert peer_state.bgp_peer_name == "bgpv4_peer2"
-    print("peer_state: {}".format(peer_state))
 
     prefixes = peer_state.ipv4_unicast_prefixes
     assert len(prefixes) == 5
@@ -240,7 +237,6 @@ def test_bgp_prefix_states_ipv4_b2b(api, b2b_raw_config, utils):
     assert any(c.as_number == 1 for c in p.communities)
 
 
-@pytest.mark.skip("Not Implemented: learned-prefix state for BGP peers")
 def test_bgp_prefix_states_all_peers_b2b(api, b2b_raw_config, utils):
     """
     Empty bgp_peer_names must return learned-prefix state for every
@@ -260,6 +256,7 @@ def test_bgp_prefix_states_all_peers_b2b(api, b2b_raw_config, utils):
     )
 
     req = api.states_request()
+    req.choice = "bgp_prefixes"
     # Leave bgp_peer_names empty → should return both peers
     states = api.get_states(req)
 


### PR DESCRIPTION
**Summary**
Implements the **bgp_prefixes** choice of the OTG **StatesRequest/StatesResponse** API on the **IxNetwork backend.** Previously get_states only accepted ipv4_neighbors and ipv6_neighbors; callers asking for learned BGP routes got a TypeError. This PR adds end-to-end support for querying learned **IPv4/IPv6 unicast prefixes** from configured BGP peers and translating them into OTG-shaped BgpPrefixesState objects.

**What changed**
[snappi_ixnetwork/device/ngpf.py]

- Routes request.choice == "bgp_prefixes" to a new get_bgp_prefix_states().
- Resolves the requested peer names to live IxNetwork peer objects, fetches learned prefixes per peer session, and returns {"choice": "bgp_prefixes", "bgp_prefixes": [...]} with results keyed under ipv4_unicast_prefixes / ipv6_unicast_prefixes by family.
- Updated the unsupported-choice error message accordingly.

[snappi_ixnetwork/device/bgp.py]
- **Config**: learned_information_filter on a BGP peer is now applied as IxNetwork multivalues (filterIpV4Unicast / filterIpV6Unicast) for both BGPv4 and BGPv6 peers. Without at least one filter enabled, IxNetwork stores nothing in learnedInfo, so this is required for the retrieval path to return data.
- **Peer resolution** (get_bgp_peer_objects): walks Topology → DeviceGroup → Ethernet → Ipv4/Ipv6 → BgpIpv4Peer/BgpIpv6Peer and maps snappi peer names to (name, peer_obj, 1-based session index, family). Handles both non-compacted single-session peers and compacted multi-session scalable peers (session index derived from the name's position in the ixn_objects names list). An empty bgp_peer_names means all peers; unknown names raise.
- **Table retrieval** (_get_learned_table): triggers GetAllLearnedInfo() and reads LearnedInfo.find().Table.find(). Note the deliberate choice of GetAllLearnedInfo over GetIPv4/6LearnedInfo — the latter only updates the deprecated inline Columns/Values fields that IxNetwork 10.x no longer writes.
- **Row → OTG translation** (_row_to_ipv4_prefix / _row_to_ipv6_prefix): column-name lookups use ordered alias tuples so the code tolerates IxNetwork version-to-version naming drift. Handles address columns that carry either a bare address plus a separate prefix-length column or a full CIDR string, distinguishes IPv4 vs IPv6 next hops (including the legacy single Next Hop column), and populates origin, local_preference, multi_exit_discriminator, and path_id only when the source cell holds a real value (N/A/empty/0 are skipped).
- **AS-path parser** (_parse_as_path): converts IxNetwork AS-path strings into OTG segment lists, including {...} AS_SET, (...) AS_CONFED_SEQ, and [...] AS_CONFED_SET groupings interleaved with plain AS_SEQ runs.
- **Community parser** (_parse_communities): handles as:custom pairs (tolerating whitespace around the colon) and well-known values (no-export, no-advertise, no-export-subconfed, llgr_stale, no_llgr); unrecognised tokens are logged and skipped rather than raising.
- **Filtering** (_apply_v4_filters / _apply_v6_filters): applies ipv4_unicast_filters / ipv6_unicast_filters from the request. Filters are OR-ed with each other; fields within a filter (addresses, prefix_length, origin, path_id) are AND-ed, and unset fields act as wildcards. No filters means no restriction.

**Tests**
[tests/bgp/test_bgp_prefix_states.py]

- **test_bgp_prefix_states_ipv4_b2b** — verifies learned IPv4 prefixes, spot-checks address/prefix-length/next-hop, asserts the AS-path carries exactly one AS_SEQ [100, 200] segment, and checks community translation.
- **test_bgp_prefix_states_all_peers_b2b** — empty bgp_peer_names returns state for all configured peers.
- **test_bgp_prefix_states_ipv6_b2b** — same coverage over a dual-stack config.
- **test_bgp_prefix_states_filter_b2b** — 5 prefixes unfiltered, narrowed to 100.1.0.0/24 with an address filter.

